### PR TITLE
Add Tekton PipelineRun configurations for openshift-selinuxd containers

### DIFF
--- a/.tekton/openshift-selinuxd-rhel8-container-release-0-9-pull-request.yaml
+++ b/.tekton/openshift-selinuxd-rhel8-container-release-0-9-pull-request.yaml
@@ -7,15 +7,16 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.go"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-0.9"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: security-profiles-operator-dev
-    appstudio.openshift.io/component: openshift-selinuxd-rhel9-container
+    appstudio.openshift.io/application: security-profiles-operator-release-0-9
+    appstudio.openshift.io/component: openshift-selinuxd-rhel8-container-release-0-9
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-selinuxd-rhel9-container-on-pull-request
+  name: openshift-selinuxd-rhel8-container-release-0-9-on-pull-request
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -24,15 +25,15 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-isc-tenant/openshift-selinuxd-rhel9-container:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/openshift-selinuxd-rhel8-container-release:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: images/el9/Dockerfile.openshift
+    value: images/el8/Dockerfile.openshift
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "konflux/el9"}, {"type": "gomod", "path": "."}]'
+    value: '[{"type": "rpm", "path": "konflux/el8"}, {"type": "gomod", "path": "."}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -613,7 +614,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-openshift-selinuxd-rhel9-container
+    serviceAccountName: build-pipeline-openshift-selinuxd-rhel8-container
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openshift-selinuxd-rhel8-container-release-0-9-push.yaml
+++ b/.tekton/openshift-selinuxd-rhel8-container-release-0-9-push.yaml
@@ -6,16 +6,15 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.go"
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-0.9"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: security-profiles-operator-dev
-    appstudio.openshift.io/component: containers-selinuxd
+    appstudio.openshift.io/application: security-profiles-operator-release-0-9
+    appstudio.openshift.io/component: openshift-selinuxd-rhel8-container-release-0-9
     pipelines.appstudio.openshift.io/type: build
-  name: containers-selinuxd-on-push
+  name: openshift-selinuxd-rhel8-container-release-0-9-on-push
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -24,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-isc-tenant/containers-selinuxd:{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/openshift-selinuxd-rhel8-container-release:{{revision}}
   - name: dockerfile
     value: images/el8/Dockerfile.openshift
   - name: hermetic
@@ -147,7 +146,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
         - name: kind
           value: task
         resolver: bundles
@@ -199,7 +198,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d48c621ae828a3cbca162e12ec166210d2d77a7ba23b0e5d60c4a1b94491adeb
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:1f6e2c9beba52d21c562ba1dea55f579f67e33b80099615bfd2043864896284d
         - name: kind
           value: task
         resolver: bundles
@@ -611,7 +610,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-containers-selinuxd
+    serviceAccountName: build-pipeline-openshift-selinuxd-rhel8-container
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openshift-selinuxd-rhel9-container-release-0-9-pull-request.yaml
+++ b/.tekton/openshift-selinuxd-rhel9-container-release-0-9-pull-request.yaml
@@ -12,10 +12,10 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: security-profiles-operator-dev
-    appstudio.openshift.io/component: containers-selinuxd
+    appstudio.openshift.io/application: security-profiles-operator-release-0-9
+    appstudio.openshift.io/component: openshift-selinuxd-rhel9-container-release-0-9
     pipelines.appstudio.openshift.io/type: build
-  name: containers-selinuxd-on-pull-request
+  name: openshift-selinuxd-rhel9-container-release-0-9-on-pull-request
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -24,15 +24,15 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-isc-tenant/containers-selinuxd:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/openshift-selinuxd-rhel9-container:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: images/el8/Dockerfile.openshift
+    value: images/el9/Dockerfile.openshift
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "konflux/el8"}, {"type": "gomod", "path": "."}]'
+    value: '[{"type": "rpm", "path": "konflux/el9"}, {"type": "gomod", "path": "."}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -613,7 +613,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-containers-selinuxd
+    serviceAccountName: build-pipeline-openshift-selinuxd-rhel9-container
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openshift-selinuxd-rhel9-container-release-0-9-push.yaml
+++ b/.tekton/openshift-selinuxd-rhel9-container-release-0-9-push.yaml
@@ -12,9 +12,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: security-profiles-operator-dev
-    appstudio.openshift.io/component: openshift-selinuxd-rhel9-container
+    appstudio.openshift.io/component: openshift-selinuxd-rhel9-container-release-0-9
     pipelines.appstudio.openshift.io/type: build
-  name: openshift-selinuxd-rhel9-container-on-push
+  name: openshift-selinuxd-rhel9-container-release-0-9-on-push
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -107,6 +107,11 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
     - default:
       - linux/x86_64
       - linux/ppc64le
@@ -141,7 +146,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
         - name: kind
           value: task
         resolver: bundles
@@ -193,7 +198,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d48c621ae828a3cbca162e12ec166210d2d77a7ba23b0e5d60c4a1b94491adeb
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:1f6e2c9beba52d21c562ba1dea55f579f67e33b80099615bfd2043864896284d
         - name: kind
           value: task
         resolver: bundles
@@ -228,6 +233,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/konflux/el8/rpms.lock.yaml
+++ b/konflux/el8/rpms.lock.yaml
@@ -5,1785 +5,1785 @@ arches:
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/c/container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 72367
     checksum: sha256:dacec63c6fc997fc110480f94a42dde032c3ba34c228807ba967c4f6f78a92fa
     name: container-selinux
     evr: 2:2.229.0-2.module+el8.10.0+22931+799fd806
     sourcerpm: container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/c/cpp-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 11297080
     checksum: sha256:794f9f929da4f11c55a12a100dc33447a8187d97375536c4fbb7e0be7ef47450
     name: cpp
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/d/delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 4454682
     checksum: sha256:65c9cfbedd22a0a4c00e0cbc2b3674e259c5233937e7292f72b009b4eb882e4b
     name: delve
     evr: 1.24.1-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/gcc-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 22284316
     checksum: sha256:e0d728aef59b8cff43092381453b851fea2d89b3ed856cae80cea0666f8ca6be
     name: gcc
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/git-2.43.5-2.el8_10.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 94588
     checksum: sha256:4d87d104887cd5c0e273bfdbb84eaa5cf284f2727ed0a303fe59a7955a2c4bd5
     name: git
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/git-core-2.43.5-2.el8_10.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 13140520
     checksum: sha256:6856ca7fcef3790043eb199ea4adb873f02f288065ec72e0a6e9a394885b56c6
     name: git-core
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/git-core-doc-2.43.5-2.el8_10.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 3214228
     checksum: sha256:28198b6eaefd6c9742fad921b70285b68c65fc6e8f2466e6211d32528b15bfd0
     name: git-core-doc
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 15774
     checksum: sha256:bdc242e8669e3abce316bff18a2b73e0d30709b5789301ed0edf08f429e649e5
     name: go-toolset
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 780730
     checksum: sha256:d99ba7b7117a2f42d534eaa4ef45242f371bfb7a77a9319704f99921454f3aaa
     name: golang
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/golang-bin-1.23.6-1.module+el8.10.0+22945+b2c96a17.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 69826278
     checksum: sha256:05f182c926154d621c1f942da936bb53d16aa6523cf17b0479b0b2d33cf78e2a
     name: golang-bin
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/g/golang-src-1.23.6-1.module+el8.10.0+22945+b2c96a17.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 12613790
     checksum: sha256:654ef2cb3e067bceb9ea88f1751ebe1987c787242db65198c6fc25469f1aba06
     name: golang-src
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/i/isl-0.16.1-6.el8.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 1212912
     checksum: sha256:159bdc6e390d4598d65d8d43e711fc597d185a7e3cd5fb6aca612e0da35fa1e8
     name: isl
     evr: 0.16.1-6.el8
     sourcerpm: isl-0.16.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/l/libmpc-1.1.0-9.1.el8.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 66728
     checksum: sha256:915151d8640cb5d7029d53e6a3bf3452c59c1ad2386932f5319f8439283887e3
     name: libmpc
     evr: 1.1.0-9.1.el8
     sourcerpm: libmpc-1.1.0-9.1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/l/libxkbcommon-0.9.1-1.el8.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 125688
     checksum: sha256:e9d3adb5df960913105864554af0d17ac26287f7454c13865895cec93c57cc6c
     name: libxkbcommon
     evr: 0.9.1-1.el8
     sourcerpm: libxkbcommon-0.9.1-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-Git-2.43.5-2.el8_10.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 80852
     checksum: sha256:d0eee09820f491430ce59a2a82d39182c2231a4a7880f9faeaee4163dc008d4f
     name: perl-Git
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 390810
     checksum: sha256:76fb7e521ced6db01aa523228c143305d242df2c6617d95596fc2109e4d49822
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 42972
     checksum: sha256:c39803f28ce1946f2c7d901e65768f47ee6db7258d88b0799c3d102986a3245f
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/Packages/x/xkeyboard-config-2.28-1.el8.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 801000
     checksum: sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806
     name: xkeyboard-config
     evr: 2.28-1.el8
     sourcerpm: xkeyboard-config-2.28-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/a/acl-2.2.53-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 85696
     checksum: sha256:2642506157ce204ed34b0a66c1926060e416a9603358daf05ce01abe8d1e4f08
     name: acl
     evr: 2.2.53-3.el8
     sourcerpm: acl-2.2.53-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/a/audit-libs-3.1.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 140676
     checksum: sha256:288b920b6fcc5ed36a1931cf39599b773377213dc732152975aba214d438eb03
     name: audit-libs
     evr: 3.1.2-1.el8
     sourcerpm: audit-3.1.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/b/basesystem-11-5.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 10756
     checksum: sha256:b9584e6823ffe9ccf79282bd57ee076a1e3a71c4c1020a20b5e1975141a50f14
     name: basesystem
     evr: 11-5.el8
     sourcerpm: basesystem-11-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/b/bash-4.4.20-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1666568
     checksum: sha256:cba6a84031062205eeebdcde6e64e28ccb523e4e4bbbdd6395d76aec30c018e5
     name: bash
     evr: 4.4.20-5.el8
     sourcerpm: bash-4.4.20-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/b/binutils-2.30-125.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 6765012
     checksum: sha256:2c91d02667dfc824ac17592db538d500e38e2224dd83d17b22dceb3a5ca44638
     name: binutils
     evr: 2.30-125.el8_10
     sourcerpm: binutils-2.30-125.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/b/brotli-1.0.6-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 336612
     checksum: sha256:e695072a3790e6c1229abfa1f703f081941be82064a9faab686cb7122838759f
     name: brotli
     evr: 1.0.6-3.el8
     sourcerpm: brotli-1.0.6-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/b/bzip2-libs-1.0.6-28.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 54676
     checksum: sha256:7dfc762abd1aee8de47d1501ebb45e46f30acae52afa50dc6946f926f890fa94
     name: bzip2-libs
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1006212
     checksum: sha256:5b97c63d4978f82a8d73cb83c81c438d69309bc929d35c6bebf5868f128da13f
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-80.0.el8_10
     sourcerpm: ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/chkconfig-1.19.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 209036
     checksum: sha256:e0c027f3bb254189986b2767bb788607d61ecf3a788e0d2f765390ce1f409f9f
     name: chkconfig
     evr: 1.19.2-1.el8
     sourcerpm: chkconfig-1.19.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/coreutils-8.30-15.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1369068
     checksum: sha256:e68dc6775d28c27ca343fdd74ebfeab892adb29dcf696d1d77f3b60c71749e35
     name: coreutils
     evr: 8.30-15.el8
     sourcerpm: coreutils-8.30-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/coreutils-common-8.30-15.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 2092696
     checksum: sha256:b5bf122e33328f6dba0dc0796259a39518886bac9714d00d044ab5cf1471a700
     name: coreutils-common
     evr: 8.30-15.el8
     sourcerpm: coreutils-8.30-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/cpio-2.12-11.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 276460
     checksum: sha256:36c617f63f094ec9b0830ad203633ab090154fa55ee5a8c1410e8d06ed3eade2
     name: cpio
     evr: 2.12-11.el8
     sourcerpm: cpio-2.12-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/cracklib-2.9.6-15.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 96900
     checksum: sha256:03e586f573bb9a8a463215d194a6b2bceff16d67af096883df5bbcda0ca55076
     name: cracklib
     evr: 2.9.6-15.el8
     sourcerpm: cracklib-2.9.6-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/cracklib-dicts-2.9.6-15.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 4144860
     checksum: sha256:13f54c6408ac37c8b4a24fb22af1a719d05d86206d1d4f979d71fad96ab7f319
     name: cracklib-dicts
     evr: 2.9.6-15.el8
     sourcerpm: cracklib-2.9.6-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/crypto-policies-20230731-1.git3177e06.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 65848
     checksum: sha256:05e1adb9bab2ce597e4ed4c6711f6000f0a5a56e1a85ba1a9098540633c144e7
     name: crypto-policies
     evr: 20230731-1.git3177e06.el8
     sourcerpm: crypto-policies-20230731-1.git3177e06.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/crypto-policies-scripts-20230731-1.git3177e06.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 86232
     checksum: sha256:06b11ba8e168d524a902768b07b42e1cb7a6b502de447d504d8c7b59ca7584ac
     name: crypto-policies-scripts
     evr: 20230731-1.git3177e06.el8
     sourcerpm: crypto-policies-20230731-1.git3177e06.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/cryptsetup-libs-2.3.7-7.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 539020
     checksum: sha256:bbc98ad2f929999206ca91eb941b3b7547032b4905a9f7dac1598306887d052d
     name: cryptsetup-libs
     evr: 2.3.7-7.el8
     sourcerpm: cryptsetup-2.3.7-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/curl-7.61.1-34.el8_10.3.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 366608
     checksum: sha256:167590bbdb52fdda1a6a7c1ade6c07b07ad7e737a744fa01cf94ec32dff9d8a6
     name: curl
     evr: 7.61.1-34.el8_10.3
     sourcerpm: curl-7.61.1-34.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-6.el8_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 137896
     checksum: sha256:9db8cddc32eb0924131885d0d039fc5bdda0b4148550897701e1a89dec1f5b75
     name: cyrus-sasl-lib
     evr: 2.1.27-6.el8_5
     sourcerpm: cyrus-sasl-2.1.27-6.el8_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dbus-1.12.8-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 43276
     checksum: sha256:22e74da0207e2b1b759918e8ec06264df9ba9d96ab8d3008ca0926f2b2e0f404
     name: dbus
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dbus-common-1.12.8-26.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 48092
     checksum: sha256:3093c5c1356bc92805a6821f9242a7fc947bbaa1ff427d310dc397f4ea38ef3e
     name: dbus-common
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dbus-daemon-1.12.8-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 263996
     checksum: sha256:d648650de20c839bccea073dac01c46ebc848d3212ce480f34c452e52eb16f4a
     name: dbus-daemon
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dbus-libs-1.12.8-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 204256
     checksum: sha256:674cacc5df6776653bc48ee9a624dfffea38f751b3e98c04b409f62d65ebd3ab
     name: dbus-libs
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dbus-tools-1.12.8-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 90344
     checksum: sha256:3eb8fa078b6682cc09faee3d9b2ad367ab72149eee20164ce49008577e8f6068
     name: dbus-tools
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/device-mapper-1.02.181-15.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 389568
     checksum: sha256:20c71371eac9da48d0b250a9f54d608b094fa37af5b07ca29476ff209def274c
     name: device-mapper
     evr: 8:1.02.181-15.el8_10
     sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/device-mapper-libs-1.02.181-15.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 429668
     checksum: sha256:6633b582b2649cbc31344710445f763304c4db927b3f9686cf250213081fa8e6
     name: device-mapper-libs
     evr: 8:1.02.181-15.el8_10
     sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/diffutils-3.6-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 375484
     checksum: sha256:e811b0abd14d296513d7900092e66d06736d42e46db06d06d845dcd260fbc665
     name: diffutils
     evr: 3.6-6.el8
     sourcerpm: diffutils-3.6-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/d/dracut-049-233.git20240115.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 392856
     checksum: sha256:212d39eabe66e8720f21ab1dedd0f67f69c804591c35890f87e106764f99925c
     name: dracut
     evr: 049-233.git20240115.el8
     sourcerpm: dracut-049-233.git20240115.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 78824
     checksum: sha256:677c40aaa9e8fa43fa09b16a1dea9c88ab54d437645e861e9eef80633a7be15a
     name: elfutils-debuginfod-client
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/elfutils-default-yama-scope-0.190-2.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 53904
     checksum: sha256:345728ee47941f7589211afbc839edb2101a4f2a584afd371c8dfb60c54aeeb3
     name: elfutils-default-yama-scope
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/elfutils-libelf-0.190-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 244768
     checksum: sha256:3f8c8b64321c2f04b1dc024df734fbb548276946048d7452143d7845e4cb3d2f
     name: elfutils-libelf
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/elfutils-libs-0.190-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 341980
     checksum: sha256:dbf8d00ce80e9fa0c55b00403c9cc5eed3568b8e698709595e8809514b3d6ffb
     name: elfutils-libs
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/emacs-filesystem-26.1-13.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 72256
     checksum: sha256:00cd8d7a426bfd9c80fc94077b0c87a8a7d60cd90442dc7665f6f8676452bcd7
     name: emacs-filesystem
     evr: 1:26.1-13.el8_10
     sourcerpm: emacs-26.1-13.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/e/expat-2.2.5-17.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 119236
     checksum: sha256:c7fad5d488549d79f4566b701be1f65c322096b55fd021abb4fe662eb08bf9d6
     name: expat
     evr: 2.2.5-17.el8_10
     sourcerpm: expat-2.2.5-17.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/f/file-5.33-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 80044
     checksum: sha256:70f8b9303f3c64aef8dba92b81a801fdfcba2e1e19a4ade593289a2fe22196b8
     name: file
     evr: 5.33-26.el8
     sourcerpm: file-5.33-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/f/file-libs-5.33-26.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 565384
     checksum: sha256:791ac2fa9d810c0fb55041274982e1f1bdd6b9a4fb833a792cea0217a074e2ba
     name: file-libs
     evr: 5.33-26.el8
     sourcerpm: file-5.33-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/f/filesystem-3.8-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1135836
     checksum: sha256:2633a4bbf84f4781a11dfd65d33e44d4f01af1e0bb6516aa4a4c70c08c9b71dc
     name: filesystem
     evr: 3.8-6.el8
     sourcerpm: filesystem-3.8-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/f/findutils-4.6.0-23.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 555032
     checksum: sha256:e082308da55a744cba3ceba76539c9ce8174d01ce9c6f2f3ec4bba625d8d612f
     name: findutils
     evr: 1:4.6.0-23.el8_10
     sourcerpm: findutils-4.6.0-23.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gawk-4.2.1-4.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1205792
     checksum: sha256:148134397838d4356cc46927cc35d8d3c1028a4a15641a7be31c23499fee3481
     name: gawk
     evr: 4.2.1-4.el8
     sourcerpm: gawk-4.2.1-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gdbm-1.18-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 138980
     checksum: sha256:badb5843301ddb3a544e5dd1ad08cc0c85c0eb77e832f0ad31893b2a16fecf52
     name: gdbm
     evr: 1:1.18-2.el8
     sourcerpm: gdbm-1.18-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gdbm-libs-1.18-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 65276
     checksum: sha256:c4b3f323158d08a56f68797ac1ad8ea5a5de4a5028b5f78256f0f444f140038c
     name: gdbm-libs
     evr: 1:1.18-2.el8
     sourcerpm: gdbm-1.18-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1125644
     checksum: sha256:f14b5f40e96ae727ce58c415295141645910311915d79d446403f68ff416ebad
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 339476
     checksum: sha256:eec4945093aa8b86e3c3a8ed629499ac3478be1e5f0a89d74178e277a7484750
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glib2-2.56.4-165.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 2703600
     checksum: sha256:ad5d50e0ea0d5fa3c0986e5c8580bc3d5e15c1153f4f802c93b16839ca982090
     name: glib2
     evr: 2.56.4-165.el8_10
     sourcerpm: glib2-2.56.4-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 3515976
     checksum: sha256:653266bdf56a2b9431674d322e98db8727e5bb5a1f9ff8220c37b73122a8c4fd
     name: glibc
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-all-langpacks-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 26767432
     checksum: sha256:419da318ce89632d4c996248833cf964ae4bf09cdc1a760292c10732f449b938
     name: glibc-all-langpacks
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-common-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1055244
     checksum: sha256:005b83a0dba278074b5dea0d8829aed74e9db152347f003e9a856dca6ed52c2c
     name: glibc-common
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-devel-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 108456
     checksum: sha256:f96c033df6dcc7fe7d64c9595e27e113cc15839502acefc91c404f8872b439af
     name: glibc-devel
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1867264
     checksum: sha256:8732a68c233bbf099bcd875ca9cba7884107d9c1b3221fe11ee2b5b1cc1c4b7d
     name: glibc-gconv-extra
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/glibc-headers-2.28-251.el8_10.16.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 504148
     checksum: sha256:b31079b948c08e76ef157b23b66c5b195f40ff4e07320dd174728e214b5fe11a
     name: glibc-headers
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gmp-6.1.2-11.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 296280
     checksum: sha256:bf1c42c2105978908fcdea40b35fc3b92d6cf1002df7ef5be24cd0d131e3a446
     name: gmp
     evr: 1:6.1.2-11.el8
     sourcerpm: gmp-6.1.2-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gnutls-3.6.16-8.el8_10.3.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1016908
     checksum: sha256:8a21a848d756e4694816f28b33954596c045ca47b74e84ca7d886a4ac50dd8be
     name: gnutls
     evr: 3.6.16-8.el8_10.3
     sourcerpm: gnutls-3.6.16-8.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/grep-3.1-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 289552
     checksum: sha256:5246dc8c3bae5d860cb5ca12d787e976c3ca70bc3d023350eabc8a9e88601058
     name: grep
     evr: 3.1-6.el8
     sourcerpm: grep-3.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/groff-base-1.22.3-18.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1091964
     checksum: sha256:35598d36ec3edefc4bae80f0a5b345a254ae686aa913dc92ac04d6855331c037
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/grub2-common-2.02-165.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 918848
     checksum: sha256:dba0a0d389fda562a8e32b1935e400e7f6616e72ad7d5d9b22a3488068737156
     name: grub2-common
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/grub2-tools-2.02-165.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1980116
     checksum: sha256:a802075c50edb9d01aae8b4cdf0bda9b0890c8e9e38d2d6e1c7c1bf5293063e8
     name: grub2-tools
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/grub2-tools-minimal-2.02-165.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 219492
     checksum: sha256:ea83159feb409569e6c7427d56addd6cf35a3dd436d012d0c42077874bed23d9
     name: grub2-tools-minimal
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/grubby-8.40-49.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 52660
     checksum: sha256:bb645e21c9871b6dc0cddb0f9cbab0b5a643738d50afb3e6cd18be4fc1f88a43
     name: grubby
     evr: 8.40-49.el8
     sourcerpm: grubby-8.40-49.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/g/gzip-1.9-13.el8_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 173832
     checksum: sha256:c135303cecabe633ea9981042d8f5e94fb5be7b51c21d86303999362bd7220fa
     name: gzip
     evr: 1.9-13.el8_5
     sourcerpm: gzip-1.9-13.el8_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/h/hardlink-1.3-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 30700
     checksum: sha256:ea8d6dd8c5e592d79229541874e6c2521e456e0efa5386a1fde95a7ed93ee4bd
     name: hardlink
     evr: 1:1.3-6.el8
     sourcerpm: hardlink-1.3-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/i/info-6.5-7.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 220672
     checksum: sha256:1e3b965b17db37287b542a6b6c269b9f727376c5a1c33421f652d4bb811187ab
     name: info
     evr: 6.5-7.el8
     sourcerpm: texinfo-6.5-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/j/json-c-0.13.1-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 45236
     checksum: sha256:48353659a2f9d0419b8b5621b40323329568252aa93611341114a347779a45d5
     name: json-c
     evr: 0.13.1-3.el8
     sourcerpm: json-c-0.13.1-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kbd-2.0.4-11.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 400648
     checksum: sha256:54192b322ece408e2d66f9c8b02dedbe5c90904e4292d5ee43b8dd2eac81f979
     name: kbd
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kbd-legacy-2.0.4-11.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 492864
     checksum: sha256:386ef39b87a49058e535015be3ec2a86847ed3c1bb9b56ae21c88e1c976b21ce
     name: kbd-legacy
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kbd-misc-2.0.4-11.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1550252
     checksum: sha256:b976dfc9467ba2a550a7e58cbac1885f5fc82afb90406cb42cb0d3d56096b016
     name: kbd-misc
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kernel-headers-4.18.0-553.54.1.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 12400012
     checksum: sha256:848ffaead954af0544c488afcbcaa563fab9dd099a30479385b961716e900126
     name: kernel-headers
     evr: 4.18.0-553.54.1.el8_10
     sourcerpm: kernel-4.18.0-553.54.1.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/keyutils-libs-1.5.10-9.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 35664
     checksum: sha256:d978361df9959f44c2f95c921441b55182bfd98cd8445d4d5584030b236e4f14
     name: keyutils-libs
     evr: 1.5.10-9.el8
     sourcerpm: keyutils-1.5.10-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/keyutils-libs-devel-1.5.10-9.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 49200
     checksum: sha256:c5dd7899a2780caa521a153ceeb1459474311d8167117459707f8bfd1f2f9f99
     name: keyutils-libs-devel
     evr: 1.5.10-9.el8
     sourcerpm: keyutils-1.5.10-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kmod-25-20.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 141196
     checksum: sha256:e1ec273e69edd80d4a77b8bed505828d9e96cf6f41c2b5764c50af9db7aaa3c5
     name: kmod
     evr: 25-20.el8
     sourcerpm: kmod-25-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kmod-libs-25-20.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 77312
     checksum: sha256:21a5ac3dfa6063dd03a0f025d74712ef2a8e40f5765a36842ecb211265045c56
     name: kmod-libs
     evr: 25-20.el8
     sourcerpm: kmod-25-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/kpartx-0.8.4-42.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 125612
     checksum: sha256:43dd464057c3f8593aaaad187d104b3ce6f8a6ec8fb86b333609e28df3796aef
     name: kpartx
     evr: 0.8.4-42.el8_10
     sourcerpm: device-mapper-multipath-0.8.4-42.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/krb5-devel-1.18.2-31.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 577964
     checksum: sha256:e0f471ebeff4e45ab3c326d50cb7ab0a899643c9dfdd19c783463aecec210d2a
     name: krb5-devel
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/k/krb5-libs-1.18.2-31.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 932296
     checksum: sha256:355c59017a9483eaea3d2be16713d49238b86c5db326483e5f4b4a56b1358646
     name: krb5-libs
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/less-530-3.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 178908
     checksum: sha256:4dd00220fe796e59ca5b00868e5984c15c2a2a3b778ea3fabb35ba521eca37e0
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libacl-2.2.53-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 37568
     checksum: sha256:3619e7536997b785dbd24bf5e54160f01581cde39cc9d27c02fe41fc0eea6602
     name: libacl
     evr: 2.2.53-3.el8
     sourcerpm: acl-2.2.53-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libarchive-3.3.3-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 421668
     checksum: sha256:3bc642d1513b4251522d4e3dafe553d3ff23f45fab45f19470c1e849663f28a5
     name: libarchive
     evr: 3.3.3-5.el8
     sourcerpm: libarchive-3.3.3-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libasan-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 450408
     checksum: sha256:0a13fc41251a9ef4730653ac9ebd08c5be791d3bb07145515cbb90ff309bb8b3
     name: libasan
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libatomic-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 27024
     checksum: sha256:49515c69f1ed2168f2f81407803a69a3f7d27320a4e7b9ebe695bd07c87bf16a
     name: libatomic
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libattr-2.4.48-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 28248
     checksum: sha256:58a7c06351efae8f3b1bff3b4832ed02ebc9f1018d6978b1703c6e963f26db98
     name: libattr
     evr: 2.4.48-3.el8
     sourcerpm: attr-2.4.48-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libblkid-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 248148
     checksum: sha256:6fc94c84cdf7978b59448f501ae70f65dd26982fdd4ac19f40910f5881be22dd
     name: libblkid
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcap-2.48-6.el8_9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 81276
     checksum: sha256:81cf8f60099fd3e16caa0e478781ace2c3e590d82eadfd74ef934c0803f9ca4b
     name: libcap
     evr: 2.48-6.el8_9
     sourcerpm: libcap-2.48-6.el8_9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcap-ng-0.7.11-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 35484
     checksum: sha256:69a39d978ac7d343ef208dba2f8c5cb52e15fbccde6743af227eede0150b72ba
     name: libcap-ng
     evr: 0.7.11-1.el8
     sourcerpm: libcap-ng-0.7.11-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcom_err-1.45.6-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 50876
     checksum: sha256:007a56f54e367172f956ab5e093b57ca7e0e2cfc4b905b76bfcb8d2772bd1693
     name: libcom_err
     evr: 1.45.6-5.el8
     sourcerpm: e2fsprogs-1.45.6-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcom_err-devel-1.45.6-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 39648
     checksum: sha256:b3aacfa09fa7d5aa15384436ed4d63d7dd23c652c1c4d41ac17abbe1dfaf4f55
     name: libcom_err-devel
     evr: 1.45.6-5.el8
     sourcerpm: e2fsprogs-1.45.6-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 126044
     checksum: sha256:9a1782b0ff33ad11979c039999990819c66145010e17c4af41550daf4d9d15ae
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libcurl-7.61.1-34.el8_10.3.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 328780
     checksum: sha256:1300b5b03339a6ffc756f1710e182fe5562504529337ce073618fb66e227c44d
     name: libcurl
     evr: 7.61.1-34.el8_10.3
     sourcerpm: curl-7.61.1-34.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libdb-5.3.28-42.el8_4.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 807032
     checksum: sha256:1006a763d4334fc7d1f19bfa6fd93b84def11c4e5873e99d6aa388d9d25b154c
     name: libdb
     evr: 5.3.28-42.el8_4
     sourcerpm: libdb-5.3.28-42.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libdb-utils-5.3.28-42.el8_4.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 162764
     checksum: sha256:31695dd70e6bb094386d2f9a732cdbba0aaaf60f966d9e3280cc56ec953fa5e8
     name: libdb-utils
     evr: 5.3.28-42.el8_4
     sourcerpm: libdb-5.3.28-42.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 112464
     checksum: sha256:7f8760b668bc465f9e538da9bfa281d1c881d05611ba54a0ac38a97338694ce2
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libfdisk-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 276876
     checksum: sha256:8d5ff444821ea99876d618a334312472eef861e5270e61f9b9554e209a273d23
     name: libfdisk
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libffi-3.1-24.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 40004
     checksum: sha256:16f7a238b83242cfc17becf660191b3c82ce17606cb0ad81fd7c9ac19bba84d1
     name: libffi
     evr: 3.1-24.el8
     sourcerpm: libffi-3.1-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libgcc-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 72644
     checksum: sha256:c49de20c717fbef492042dce6ae11f19d6c879eff1fb793ddeae025ff68ff4c9
     name: libgcc
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libgcrypt-1.8.5-7.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 533820
     checksum: sha256:45f33fab13c06919b98bb5e2950f51bb3863f96de8bf82654eba71d22eb9c46b
     name: libgcrypt
     evr: 1.8.5-7.el8_6
     sourcerpm: libgcrypt-1.8.5-7.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libgomp-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 219128
     checksum: sha256:c3f84939c560f46f2ac0a49784e6d52f62378e977f710cc508bdedc971efb285
     name: libgomp
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libgpg-error-1.31-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 255632
     checksum: sha256:69997f597de86de2dedda20db0f5b516585751822162f4dacd01cbc2808a9155
     name: libgpg-error
     evr: 1.31-1.el8
     sourcerpm: libgpg-error-1.31-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libidn2-2.2.0-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 98320
     checksum: sha256:7221e9c72741e31d3e954cae6a1b780b15da86abb70d6fdf3c125b1a440ce2b2
     name: libidn2
     evr: 2.2.0-1.el8
     sourcerpm: libidn2-2.2.0-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libkadm5-1.18.2-31.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 198100
     checksum: sha256:945803977f75526afa9460b8095188455921bf6d58fae4e362a9f467b936107b
     name: libkadm5
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libkcapi-1.4.0-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 56620
     checksum: sha256:014d9d23c4114c8b29c78bbaf9a003b42d507d2bdc413d7ca4be220454a85213
     name: libkcapi
     evr: 1.4.0-2.el8
     sourcerpm: libkcapi-1.4.0-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libkcapi-hmaccalc-1.4.0-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 34492
     checksum: sha256:aed8c16e3c76529545979b07753dc2ac0728c07bc9d39f0b1540473999fa9884
     name: libkcapi-hmaccalc
     evr: 1.4.0-2.el8
     sourcerpm: libkcapi-1.4.0-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libmount-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 266360
     checksum: sha256:6ce023efeb37f29a17f92b5def9fc835e48e9e3c436210463586feaeb17fe9ea
     name: libmount
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libnghttp2-1.33.0-6.el8_10.1.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 87792
     checksum: sha256:d7a306526490b3f56de7963ecf10647981c112bb2f4ed75b97344d6e0eb58f47
     name: libnghttp2
     evr: 1.33.0-6.el8_10.1
     sourcerpm: nghttp2-1.33.0-6.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 64520
     checksum: sha256:7c458f0dfbd31662e5a8a91b847881dfba6ff04786bc21e7de230236ce8ffaa7
     name: libnsl2
     evr: 1.2.0-2.20180605git4a062cf.el8
     sourcerpm: libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 39284
     checksum: sha256:be44b47bbd3f227e25f645728e55022bbe5206afa76a955f6629bc50fe9abc53
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libpsl-0.20.2-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 64796
     checksum: sha256:95971777d5b9af4cc37788f0b9193c693de7dc2f0f842f341a5d2182af4edb24
     name: libpsl
     evr: 0.20.2-6.el8
     sourcerpm: libpsl-0.20.2-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libpwquality-1.4.4-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 111984
     checksum: sha256:70b489514f078367580543b1a0633594b5491617bf2c0145c0d3b089e7194201
     name: libpwquality
     evr: 1.4.4-6.el8
     sourcerpm: libpwquality-1.4.4-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/librtas-2.0.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 70236
     checksum: sha256:94b8f8ce9926a60524cba62e9695785bf12f3ca7f6de86cbcb510889e9e61509
     name: librtas
     evr: 2.0.2-1.el8
     sourcerpm: librtas-2.0.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libseccomp-2.5.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 79580
     checksum: sha256:2ab6a785fca59959a018048b9de2edccde1b562bbf8821c9b59198cfd0621e16
     name: libseccomp
     evr: 2.5.2-1.el8
     sourcerpm: libseccomp-2.5.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libselinux-2.9-10.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 182304
     checksum: sha256:52cf0555fe9dc44219153a68fb4411c78347e96e3edb7b5830a9db28fdec3699
     name: libselinux
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libselinux-devel-2.9-10.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 205292
     checksum: sha256:8a4e85838aed459fc2d15d1c2157cd2d2cefb8ffe631d0a225d81e5e2ac17045
     name: libselinux-devel
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libselinux-utils-2.9-10.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 255160
     checksum: sha256:5f1ac57fe584d370206ca9a018163e6b88381162b4cada4182cdedb6e9a7caf0
     name: libselinux-utils
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libsemanage-2.9-11.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 183840
     checksum: sha256:7d846562212b735859d256188bf880760f37a628c00cdc89174470426688686f
     name: libsemanage
     evr: 2.9-11.el8_10
     sourcerpm: libsemanage-2.9-11.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libsepol-2.9-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 377308
     checksum: sha256:32d5f9ecb2f91bb0f170439de53978113cd52031c4ef3956f11a6c913af9cb2a
     name: libsepol
     evr: 2.9-3.el8
     sourcerpm: libsepol-2.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libsepol-devel-2.9-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 89032
     checksum: sha256:00ed6322075174e6196ee5b1cf0b659fe729d294a40bbefdf5a293c85e28cc6f
     name: libsepol-devel
     evr: 2.9-3.el8
     sourcerpm: libsepol-2.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libsigsegv-2.11-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 31524
     checksum: sha256:e1c727c81c7d54b21ebf7346d81ea57bbf77cdee59efc2c1bd57d78b45697de6
     name: libsigsegv
     evr: 2.11-5.el8
     sourcerpm: libsigsegv-2.11-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libsmartcols-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 196536
     checksum: sha256:e5ed04fe83a621f8ae92f1e9152b1c592dc9e95fbdcd4b1d8e4d221a0a350090
     name: libsmartcols
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libssh-0.9.6-14.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 246788
     checksum: sha256:e87fabf19e917162b4e06713239f02dec859b5041e8332a1394e40db93329ea5
     name: libssh
     evr: 0.9.6-14.el8
     sourcerpm: libssh-0.9.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libssh-config-0.9.6-14.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 21548
     checksum: sha256:e8281fb82a512c0bbfdd4bbd0f7f9657fce2ad547189fb93d0a0bf814173a2a4
     name: libssh-config
     evr: 0.9.6-14.el8
     sourcerpm: libssh-0.9.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libstdc++-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 528496
     checksum: sha256:471966d27c7c7501aa3f93f6df993a758bc3984b3a2d18d8eea366aa15b351e4
     name: libstdc++
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libtasn1-4.13-5.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 84436
     checksum: sha256:dd164527284c5e9fc2bfe4f758692c40b386a3f8b205b0ed21bfdd380fafe611
     name: libtasn1
     evr: 4.13-5.el8_10
     sourcerpm: libtasn1-4.13-5.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libtirpc-1.1.4-12.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 130700
     checksum: sha256:36d3f74bbeea24dc1e080d27b0062d930045c8f93a04dd30eda9959ed0fdc2ed
     name: libtirpc
     evr: 1.1.4-12.el8_10
     sourcerpm: libtirpc-1.1.4-12.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libubsan-8.5.0-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 170100
     checksum: sha256:3881c731cf9d01ea89e8ad0c9a7e47ebc23093a24123886c441a101171e4eccb
     name: libubsan
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libunistring-0.9.9-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 432636
     checksum: sha256:a7db88e037715eb0ea86ffa464285615549b23178a14d691935685bdb6df4742
     name: libunistring
     evr: 0.9.9-3.el8
     sourcerpm: libunistring-0.9.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libutempter-1.1.6-14.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 33008
     checksum: sha256:349d5e65aeee405ea53d10c651d541418f11af4bf5f436ab5cba8c07183f405e
     name: libutempter
     evr: 1.1.6-14.el8
     sourcerpm: libutempter-1.1.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libuuid-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 103444
     checksum: sha256:e74caf1e55cd53a08ce78f772e9d1b1c3b7f8b8f407221a06087ece0998a223a
     name: libuuid
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libverto-0.3.2-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 26016
     checksum: sha256:bc6ee0084111fad764d6950f891ff86d73c43a151289e808201cbf8284cbcb7f
     name: libverto
     evr: 0.3.2-2.el8
     sourcerpm: libverto-0.3.2-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libverto-devel-0.3.2-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 18480
     checksum: sha256:1b62c4364e3142f896c73285c827a66287b5e72932487f71363c9301aba45f79
     name: libverto-devel
     evr: 0.3.2-2.el8
     sourcerpm: libverto-0.3.2-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libxcrypt-4.1.1-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 78872
     checksum: sha256:4ea0dde6e89eeaf64addadffec27cbac377939755ca085e0a74571058d58352f
     name: libxcrypt
     evr: 4.1.1-6.el8
     sourcerpm: libxcrypt-4.1.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libxcrypt-devel-4.1.1-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 25824
     checksum: sha256:cbb6c0c75696efd8362f0dee4ecc5898642863accf1b1590216d60613d169b3c
     name: libxcrypt-devel
     evr: 4.1.1-6.el8
     sourcerpm: libxcrypt-4.1.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libxml2-2.9.7-19.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 772456
     checksum: sha256:5d978e667f55c6b78e0577bf05d7d7f3a17d1d075a6ececd7173131d06bb63e6
     name: libxml2
     evr: 2.9.7-19.el8_10
     sourcerpm: libxml2-2.9.7-19.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/libzstd-1.4.4-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 282940
     checksum: sha256:0143da5903a3053bbd62714904db5a7c1aba3b9ff77c97d9126a4479d3047c58
     name: libzstd
     evr: 1.4.4-1.el8
     sourcerpm: zstd-1.4.4-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/lua-libs-5.3.4-12.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 131772
     checksum: sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417
     name: lua-libs
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/l/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 75484
     checksum: sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264
     name: lz4-libs
     evr: 1.8.3-3.el8_4
     sourcerpm: lz4-1.8.3-3.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/m/make-4.2.1-11.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 516580
     checksum: sha256:b0fbe976d50d6166f1ce6bcc4d46a3320586f34b4573ccebbd033272eb8c45e5
     name: make
     evr: 1:4.2.1-11.el8
     sourcerpm: make-4.2.1-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/m/memstrack-0.2.5-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 57364
     checksum: sha256:0d1ea175d030d19945bc30ab8ca2a47fd1b8bbab67531086b38aa8cff1b2af5b
     name: memstrack
     evr: 0.2.5-2.el8
     sourcerpm: memstrack-0.2.5-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/m/mpfr-3.1.6-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 239784
     checksum: sha256:d3c4038a7a3be6987f74236394642be84092a9dd731317dfe5974af757c3ccfc
     name: mpfr
     evr: 3.1.6-1.el8
     sourcerpm: mpfr-3.1.6-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 402196
     checksum: sha256:6acd630f4fb7cd5404c5b0e1f5d3a1c0c4d22e63b60766240a2cb0dc997a440e
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/n/ncurses-base-6.1-10.20180224.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 83276
     checksum: sha256:207f5578dd44a73761178f8b01030151e44d3d046c1578446d558c5a0a2bf34a
     name: ncurses-base
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/n/ncurses-libs-6.1-10.20180224.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 369876
     checksum: sha256:753dab39ba2d7dab995b99e04206deed46ca24e47eea43ccd82af1b6ceda28d3
     name: ncurses-libs
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/n/nettle-3.4.1-7.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 335516
     checksum: sha256:5fe74bc2be03b6c3f90cf89fe9561982e16ee368c5641cb28cc48acb40e07bb1
     name: nettle
     evr: 3.4.1-7.el8
     sourcerpm: nettle-3.4.1-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openldap-2.4.46-21.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 389812
     checksum: sha256:1cf90e18548b0dd9324d8bed004f97d23c405939646027b24d75f0a6a0044f30
     name: openldap
     evr: 2.4.46-21.el8_10
     sourcerpm: openldap-2.4.46-21.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssh-8.0p1-25.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 536628
     checksum: sha256:f624796559408c304a8cd384c9607066bc5c5b097537c262b717c832c0f6f965
     name: openssh
     evr: 8.0p1-25.el8_10
     sourcerpm: openssh-8.0p1-25.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssh-clients-8.0p1-25.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 706612
     checksum: sha256:fa64a5c4a47892bd97d5dc023c5eb6fb011c42ff275ef8bc1f7b0801df253eb4
     name: openssh-clients
     evr: 8.0p1-25.el8_10
     sourcerpm: openssh-8.0p1-25.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 731808
     checksum: sha256:13616f555100e3a9b4617fe4d3aa13c4a1f46237708572b379749863ee1fb7ae
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssl-devel-1.1.1k-14.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 2438932
     checksum: sha256:63b9e8b8601e80e821f8a916814a5736a504f42b89edbc08771db04ababe2fbc
     name: openssl-devel
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssl-libs-1.1.1k-14.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1580468
     checksum: sha256:92db3c863ae63eb9e59c9adacba4d7e80a0ebfd466c2074102fc051272642892
     name: openssl-libs
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/openssl-pkcs11-0.4.10-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 73064
     checksum: sha256:161238688f2bddf6a51353e4a96dc912993b32f41c6653f86b7fb9d338032e49
     name: openssl-pkcs11
     evr: 0.4.10-3.el8
     sourcerpm: openssl-pkcs11-0.4.10-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/o/os-prober-1.74-9.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 57116
     checksum: sha256:0db7648b03c119d2a1361712aed1c06e8ab0780adb29572da2d11a7f5e7e6770
     name: os-prober
     evr: 1.74-9.el8
     sourcerpm: os-prober-1.74-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/p11-kit-0.23.22-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 335268
     checksum: sha256:fb4b1e3d670d2ee0db38ee33ed014770bf5937fa359f0c60d18c56d30d32dcba
     name: p11-kit
     evr: 0.23.22-2.el8
     sourcerpm: p11-kit-0.23.22-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/p11-kit-trust-0.23.22-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 152548
     checksum: sha256:fa8d8e7c54175b0ab406629b41a71884d97acba2d6fcc170d6355c2102d6280f
     name: p11-kit-trust
     evr: 0.23.22-2.el8
     sourcerpm: p11-kit-0.23.22-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pam-1.3.1-36.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 812356
     checksum: sha256:791f57c8be96fb1e8a1777efe5f2c0283e59bf661947b4281e01505fdfa4a510
     name: pam
     evr: 1.3.1-36.el8_10
     sourcerpm: pam-1.3.1-36.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pcre-8.42-6.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 211436
     checksum: sha256:7751a9bafb0e920879c9a3ce5480fae955b05f83a9633fe8c41c83fcd0df227b
     name: pcre
     evr: 8.42-6.el8
     sourcerpm: pcre-8.42-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pcre2-10.32-3.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 243688
     checksum: sha256:21030b61a5ceeb9d8cb1aaf24dd592be14c6ee92c7eb52923d8a686e2795ea61
     name: pcre2
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pcre2-devel-10.32-3.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 619360
     checksum: sha256:536b5b685cc842fcb084c5479f19f95c29bd2ad9edf88723601cfe9c311005c0
     name: pcre2-devel
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pcre2-utf16-10.32-3.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 224844
     checksum: sha256:953f9ecc8ec49332880c8bc86cb985a604bcff533928600e8e998aa851ee6e28
     name: pcre2-utf16
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pcre2-utf32-10.32-3.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 218320
     checksum: sha256:64ac0bc3cbde1e11bd245b457308d654de5f7d50e4caebe335bf17c4d7399190
     name: pcre2-utf32
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 59924
     checksum: sha256:481d6065068ab8fd3bef7fa0539e73ca8ede56ecb652dc3974eb7d2244670aee
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 38828
     checksum: sha256:c7efac801bc1b89d979c6eef9eae0fc75dc322bc15060b8cdc396fe1def0564b
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Encode-2.97-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1530288
     checksum: sha256:3ee2ccbfee32f806afec5a5e873423d49c5ba88a3c425b98663ac95be4c62a10
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Errno-1.28-422.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 78356
     checksum: sha256:57dd645ef12850ad5a499f0aa49e30e796b3c75e505704df57074f9743ca2f3d
     name: perl-Errno
     evr: 1.28-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-IO-1.38-422.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 146432
     checksum: sha256:d92a845b46a5ad9f64b46cdc735b7471a24672251407153312f4f471ac9b94f8
     name: perl-IO
     evr: 1.38-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 32240
     checksum: sha256:44e0e3afc547cbbff4a3ae8a8788712bf2917ff5050dc6fcf969cf78b71d385e
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 93220
     checksum: sha256:759d2a6cb209926af2799c1f25851e28a34f6af7e55f93a68045776bb2519379
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 72272
     checksum: sha256:abf49a75e3221dce4a379c9300b15611dc4a45acc109862e88146441776d0343
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Socket-2.027-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 60844
     checksum: sha256:941fb8859ba0911c8d42d7fadb9a70e89155013f3fa697bb61ba5a18661a1d45
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Storable-3.11-3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 102044
     checksum: sha256:8d54cc441cf480bc016c027df4acfd938373a19d91a7fd00749e4d2de3c36bfd
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 82096
     checksum: sha256:ec12527a8c08222f2d4552bd2a5c1729764c180950fe5fec9ca4dcb97e4099c6
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-interpreter-5.26.3-422.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 6633656
     checksum: sha256:f45b6796e4c5d35f234f540c3d28e4d44db89db318abd253c9b66eda9daae981
     name: perl-interpreter
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-libs-5.26.3-422.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1657456
     checksum: sha256:ad4198a5ea9fdeca890c41a4014948b1cf64af9f40c3699ba79f1d1a543d4ed6
     name: perl-libs
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-macros-5.26.3-422.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 74268
     checksum: sha256:175edb97b4aa4e0eda35c13b58df0cbd252e8ecb0d6739ce6a4e37eae8a81dee
     name: perl-macros
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-threads-2.21-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 63064
     checksum: sha256:ac56f03020c08a0e56aa90d369d68ed6c558786b828c575b266c3e7967eae61d
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 50192
     checksum: sha256:e1f1f3beb08cd5f29b2daa92593822fdd2c5af843b0532b0e8925180e3e931a2
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pigz-2.4-4.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 81812
     checksum: sha256:d8b5b571fb84c7ccfa24f8a20460471d41fc4487d6d0c34f91fbeaba4c857eb2
     name: pigz
     evr: 2.4-4.el8
     sourcerpm: pigz-2.4-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 39616
     checksum: sha256:5247ecf6db41cf55db819e36b36be26806bac55d542183e8375177f582420035
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 15616
     checksum: sha256:0a5344c56c015390b8e0e638246f3ccfef654bf185735b8f8238ef804f9912eb
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/platform-python-3.6.8-69.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 91148
     checksum: sha256:8f3268150c6462891740e74e36aa0d512376278b3661b80b66e392d727f137b7
     name: platform-python
     evr: 3.6.8-69.el8_10
     sourcerpm: python3-3.6.8-69.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/platform-python-pip-9.0.3-24.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1633024
     checksum: sha256:a9104ca3388b74f665c2648cde81043cc7748bf1ca5a7f2a4148b86013206fc8
     name: platform-python-pip
     evr: 9.0.3-24.el8
     sourcerpm: python-pip-9.0.3-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/platform-python-setuptools-39.2.0-8.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 647476
     checksum: sha256:8f330a8602613473b6e4c0bc57cb3012932a9a9399ea7a3fa65175453a6580ab
     name: platform-python-setuptools
     evr: 39.2.0-8.el8_10
     sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/policycoreutils-2.9-26.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 388696
     checksum: sha256:aaab9cee6c7a650511112b37eacbaaccc39991f686b940392b23540a7d024cc4
     name: policycoreutils
     evr: 2.9-26.el8_10
     sourcerpm: policycoreutils-2.9-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/popt-1.18-1.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 66608
     checksum: sha256:f26f3047eb046f4497a6d643002c4fb8f49a58c6699aadb39a9d81da89df3306
     name: popt
     evr: 1.18-1.el8
     sourcerpm: popt-1.18-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/procps-ng-3.3.15-14.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 353488
     checksum: sha256:9e6b3e33b030fccdc374760de593c064a357428d92bdeb3e3523ee4724ed789a
     name: procps-ng
     evr: 3.3.15-14.el8
     sourcerpm: procps-ng-3.3.15-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 57592
     checksum: sha256:f8c191d8b952621d10a1055be960bbe07be66f557c5a9d007f8908abcde1b9af
     name: publicsuffix-list-dafsa
     evr: 20180723-1.el8
     sourcerpm: publicsuffix-list-20180723-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/python3-libs-3.6.8-69.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 8547056
     checksum: sha256:9a152eef0bed0e9e017eca728deb0abd85e2368119f875b691bc919b9d140588
     name: python3-libs
     evr: 3.6.8-69.el8_10
     sourcerpm: python3-3.6.8-69.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/python3-pip-wheel-9.0.3-24.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 886996
     checksum: sha256:9bf511b12174637c1163f224deb28a0ea7f8f4565231e3a0e8eb64f37ce27d08
     name: python3-pip-wheel
     evr: 9.0.3-24.el8
     sourcerpm: python-pip-9.0.3-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/p/python3-setuptools-wheel-39.2.0-8.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 296040
     checksum: sha256:833dcb68b1eea48bfb8853886236753647743258fd74cc538ffa72408aab9213
     name: python3-setuptools-wheel
     evr: 39.2.0-8.el8_10
     sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/readline-7.0-10.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 215544
     checksum: sha256:d8ba6a91610d87dfb599018c887514af663a0f963ed6b25a83bac8fba56fa266
     name: readline
     evr: 7.0-10.el8
     sourcerpm: readline-7.0-10.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/redhat-release-8.10-0.3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 46592
     checksum: sha256:5597e2a5503d465b15f1328e1cd4bd9276372c2f389179a7f3fb2e76b47cbffa
     name: redhat-release
     evr: 8.10-0.3.el8
     sourcerpm: redhat-release-8.10-0.3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/redhat-release-eula-8.10-0.3.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 21300
     checksum: sha256:6be50f39102aebea9729db40fc9dc85b399a9946eca3ecab895df903b2ed115e
     name: redhat-release-eula
     evr: 8.10-0.3.el8
     sourcerpm: redhat-release-8.10-0.3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/rpm-4.14.3-32.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 558564
     checksum: sha256:4b8359a142004d55229eae1787962dcab670097f7daa3a942e104945dd9a782f
     name: rpm
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/rpm-libs-4.14.3-32.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 391648
     checksum: sha256:c86a5a90ed762d37d9a03d2ffe7d935ff9f52bf757e20a242ba3c481d6278526
     name: rpm-libs
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/r/rpm-plugin-selinux-4.14.3-32.el8_10.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 80720
     checksum: sha256:f0347e62e7830da4339a138a7208b67af5bd8f219b7e64c4a3c70bf50ca5461f
     name: rpm-plugin-selinux
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/sed-4.5-5.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 310120
     checksum: sha256:e56fa11086504b48d03283d40f3f92b98288c1388c8c58ebf874ee52a3d68365
     name: sed
     evr: 4.5-5.el8
     sourcerpm: sed-4.5-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/selinux-policy-3.14.3-139.el8_10.1.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 685712
     checksum: sha256:9fa9ef9f606ef3a0d62bdf0fe98d9847fe511333f23bd791f1a6ad22ff62b2a1
     name: selinux-policy
     evr: 3.14.3-139.el8_10.1
     sourcerpm: selinux-policy-3.14.3-139.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/selinux-policy-targeted-3.14.3-139.el8_10.1.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 16155856
     checksum: sha256:7289ba82da048c506f2e22053bda0229d4f8d85f7657ba20cdc0043cc8d8f372
     name: selinux-policy-targeted
     evr: 3.14.3-139.el8_10.1
     sourcerpm: selinux-policy-3.14.3-139.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/setup-2.12.2-9.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 185300
     checksum: sha256:da010e1bf1c658361a7b2a38c86bcfc82470c994b2793f5f80509d73cb468fd6
     name: setup
     evr: 2.12.2-9.el8
     sourcerpm: setup-2.12.2-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/shadow-utils-4.6-22.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1310120
     checksum: sha256:20e487410c60bf49e6f80649f374387738e8a5d11ebf6b3e418298e0887237f0
     name: shadow-utils
     evr: 2:4.6-22.el8
     sourcerpm: shadow-utils-4.6-22.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/shared-mime-info-1.9-4.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 341608
     checksum: sha256:376c4d53d84994b231524dff08ef0656da85e0c3fdafcbf59010d16657f6287b
     name: shared-mime-info
     evr: 1.9-4.el8
     sourcerpm: shared-mime-info-1.9-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/sqlite-libs-3.26.0-19.el8_9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 640528
     checksum: sha256:7b405b525dafb123f1d704ea9d8835db94d617befa89df011b1c391b6cec6140
     name: sqlite-libs
     evr: 3.26.0-19.el8_9
     sourcerpm: sqlite-3.26.0-19.el8_9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/systemd-239-82.el8_10.5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 3884024
     checksum: sha256:76958d20032f290e803f274e3636ec052c2b75ec1c283dfe5e311cca5e282e73
     name: systemd
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/systemd-libs-239-82.el8_10.5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1200964
     checksum: sha256:4290159f325f478e602ac5758f787b12b84d265713fffae6310a2ffd5eff0212
     name: systemd-libs
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/systemd-pam-239-82.el8_10.5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 551196
     checksum: sha256:0b8f8c99434ca12a31ea86412609f926ffe0519cc5668ad64526d0f6aeba2ad9
     name: systemd-pam
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/s/systemd-udev-239-82.el8_10.5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 1625756
     checksum: sha256:3a43942c51205285c3bc759e98999ebf8647b55bdc740041164547856dcc4d51
     name: systemd-udev
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/t/tar-1.30-9.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 878620
     checksum: sha256:c34619440c83b785306420d9ae4a21ccbafe09815e5631510cccb6433f435a47
     name: tar
     evr: 2:1.30-9.el8
     sourcerpm: tar-1.30-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/t/trousers-0.3.15-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 159044
     checksum: sha256:bba868fd86f489aa88e9351ea5bdd48be886b22e99572970a1defe2741868db4
     name: trousers
     evr: 0.3.15-2.el8
     sourcerpm: trousers-0.3.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/t/trousers-lib-0.3.15-2.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 180376
     checksum: sha256:b3a3146c5a9cfcda05e4fd813d473c02eacc4928b09f6473adcfc83c51950e47
     name: trousers-lib
     evr: 0.3.15-2.el8
     sourcerpm: trousers-0.3.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/t/tzdata-2025b-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 488428
     checksum: sha256:338539f7f0cd2770694153af81e2e65121b050a1bb555ad66a6fb6f562732602
     name: tzdata
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/u/util-linux-2.32.1-46.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 2701400
     checksum: sha256:67ac1c1d100dd3022074c357030dab31c776b74ac10d1a14cda6c3b45f10f8e2
     name: util-linux
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/w/which-2.21-20.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 51916
     checksum: sha256:2919c28229e59486ec8417797e0cd7b0c046779ec1952c1b76d0987d9a977dbb
     name: which
     evr: 2.21-20.el8
     sourcerpm: which-2.21-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/x/xz-5.2.4-4.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 162264
     checksum: sha256:80d2fc754452ae52b3b36504e5cceb5cd5435a97999351402ae7a28298592a01
     name: xz
     evr: 5.2.4-4.el8_6
     sourcerpm: xz-5.2.4-4.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/x/xz-libs-5.2.4-4.el8_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 114888
     checksum: sha256:e36fd1e6fd97ebf2fd83631d14928faf557a7a8459676b641eb0a4140059f97c
     name: xz-libs
     evr: 5.2.4-4.el8_6
     sourcerpm: xz-5.2.4-4.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/z/zlib-1.2.11-25.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 115624
     checksum: sha256:f0dc7707a13407191e48bd5afbc7e72d33ef3c3c4af0e0fcba079041e1804f4b
     name: zlib
     evr: 1.2.11-25.el8
     sourcerpm: zlib-1.2.11-25.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/Packages/z/zlib-devel-1.2.11-25.el8.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-ppc64le-baseos-rpms
     size: 59972
     checksum: sha256:8cd15aba15bc57e08d326c6dc160a7ded28adbce928da72714a1950392100f60
     name: zlib-devel
@@ -1791,2790 +1791,2790 @@ arches:
     sourcerpm: zlib-1.2.11-25.el8.src.rpm
   source:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/c/container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 68445
     checksum: sha256:97e408e247ad39d0c2365a5c777ae725e4e515e1d9e386ea6f500899b3bbc026
     name: container-selinux
     evr: 2:2.229.0-2.module+el8.10.0+22931+799fd806
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/d/delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 9617211
     checksum: sha256:f2cc1f7ce0ff833db04bb5b97d495bebb38525cf034f0ac7d5abbffd3468bd04
     name: delve
     evr: 1.24.1-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el8_10.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 7492234
     checksum: sha256:84abeac488878a765f05d3161f22684c2fb0bcdf8abcd9cf7a5378da936b7ea0
     name: git
     evr: 2.43.5-2.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/g/go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 18120
     checksum: sha256:f7db9f33a706444f6b51f46ed0d250cf6bf905ca117fe827b38a48cfd157d1a4
     name: go-toolset
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/g/golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 28202728
     checksum: sha256:da4c25b57a92457c1dd29297864bcabad04c383fddc5360299da6c5352cee852
     name: golang
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/i/isl-0.16.1-6.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 2707870
     checksum: sha256:0b30f2b8493eed1143ef416bfe9224db269e282a5e7a43cad6a2d13cb6311beb
     name: isl
     evr: 0.16.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/l/libmpc-1.1.0-9.1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 1271618
     checksum: sha256:abc6027ff19edf00eb50dd86e37facba5bd9898da9ccd8aa9cc1f934fbe68e58
     name: libmpc
     evr: 1.1.0-9.1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/l/libxkbcommon-0.9.1-1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 390739
     checksum: sha256:ca72f33bbbdd245bf1d2385e5f934d36b0ebdc9854b242fce7be0bb56bfa8255
     name: libxkbcommon
     evr: 0.9.1-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/p/perl-Error-0.17025-2.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 50040
     checksum: sha256:37a96e1b17c437d30b66159af7ff16681d2de05fe063db57e61261caf7f00d2b
     name: perl-Error
     evr: 1:0.17025-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 342192
     checksum: sha256:d5ad0d4f7fb6c7bdf176cbf04f9a8b2763fe58329155c4c52a6e13e4cc0dc4e8
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 169249
     checksum: sha256:ae5fce417f096e72b57e410058740582f34253a2544019da19324aea3b71f598
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 494211
     checksum: sha256:29f51f6c0a352cc9dbbc1f7b5a04de7a8a50611fe7c1ec32c7ebce4a1b456689
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.37-7.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 101242
     checksum: sha256:168b753e84508c60384408710a0c305b4e8ead3ff1163abae23e48d16e14d77c
     name: perl-TermReadKey
     evr: 2.37-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.28-1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-ppc64le-appstream-source-rpms
     size: 1699339
     checksum: sha256:e17ddb6b3789908ccb750893fda134141e08ae0fd0618cc6b059d46257ba200f
     name: xkeyboard-config
     evr: 2.28-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/a/acl-2.2.53-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 549872
     checksum: sha256:3f8720a9425f7575d0314034538412a54e6cc482cc642bcdccb95679e362ef93
     name: acl
     evr: 2.2.53-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/a/attr-2.4.48-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 491219
     checksum: sha256:07bef8d477176042b940e5732eba1600871aacc1a0dbe679952d62265b5e6dbc
     name: attr
     evr: 2.4.48-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/a/audit-3.1.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1248664
     checksum: sha256:c1facd2ecc520c758bbe2b049207629ad08914798f63c92beef4790086ad2f29
     name: audit
     evr: 3.1.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/b/basesystem-11-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 11934
     checksum: sha256:95fb2c11bd59c51fcb0c0239e3e2c307d7d8d40c24b2960792bbc8af8c14f95c
     name: basesystem
     evr: 11-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/b/bash-4.4.20-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 9478334
     checksum: sha256:670d393f3d288bc61519be0d2c5378addc1cd4a752b738ce2424b69618f3965c
     name: bash
     evr: 4.4.20-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/b/binutils-2.30-125.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 21080005
     checksum: sha256:3dfe179ebe80b9640e735710b9f01476905687dc10e5a3516438b24d65e66ff3
     name: binutils
     evr: 2.30-125.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/b/brotli-1.0.6-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 23835509
     checksum: sha256:d269796bbd35c8ef524e4070d347f8b74cf1f10caa1bd4b19c30d69f24761f2a
     name: brotli
     evr: 1.0.6-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/b/bzip2-1.0.6-28.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 807250
     checksum: sha256:9c1d697f675f5889c57e7f983afa4b3e3f6e2334887ded9d7c10c5a205d1b06a
     name: bzip2
     evr: 1.0.6-28.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 715540
     checksum: sha256:a066b501d49019ad53d7a8bd7badd1b073f317e406561f0cfad59b7bdfaba0a6
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-80.0.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/chkconfig-1.19.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 221618
     checksum: sha256:7cf522c35fa5a5906c8c793ece9e599e80aba6c37d3f57afbf436c9abb8629c6
     name: chkconfig
     evr: 1.19.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/coreutils-8.30-15.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5550193
     checksum: sha256:8e6d8f3d8929cfd896c09a6d7ebfdd0d78fd028169042f7df9e35803189e4eee
     name: coreutils
     evr: 8.30-15.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/cpio-2.12-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1312438
     checksum: sha256:23581dd4cd8175797ee2c6c4ae48fd679e8d3a5375ebc41df056a497334443db
     name: cpio
     evr: 2.12-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-15.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 6423670
     checksum: sha256:835902fc3455d9e3b132ed1f8f63eefc4adf1c7d505771604ff89cb2f0116f0c
     name: cracklib
     evr: 2.9.6-15.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/crypto-policies-20230731-1.git3177e06.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 97044
     checksum: sha256:48c7b69ead3bf12dfb7c1d20807f63057429636325aae5bd6f1ae166b38fcf2e
     name: crypto-policies
     evr: 20230731-1.git3177e06.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/cryptsetup-2.3.7-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 11381421
     checksum: sha256:21bb087ab9a3d64c89295a1bd45b5e5b6189832a972d4b3ddccb2ff5437ac2ed
     name: cryptsetup
     evr: 2.3.7-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/curl-7.61.1-34.el8_10.3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2629169
     checksum: sha256:da74fbd455075a1e124a5251e17946c0a2c8b8bd023e349d0c52b3cee8e3d37c
     name: curl
     evr: 7.61.1-34.el8_10.3
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-6.el8_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 4032772
     checksum: sha256:72d534b444990dbb647ead881f77e841ef9416109054cf74b7a5d12f912eef9a
     name: cyrus-sasl
     evr: 2.1.27-6.el8_5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/d/dbus-1.12.8-26.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2149642
     checksum: sha256:4934fea4bcebaf82dacd6d8258b35233f25e66cfd45d68f6b6e48d2ff3632395
     name: dbus
     evr: 1:1.12.8-26.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/d/device-mapper-multipath-0.8.4-42.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 770004
     checksum: sha256:1d1b1002cc499a2ab55a5288260f666fd0f6e077166708dd47d8f02efcfd3bd2
     name: device-mapper-multipath
     evr: 0.8.4-42.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/d/diffutils-3.6-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1427759
     checksum: sha256:1308e782ad4f9b17a5cbbac9734be496948db857de7458b3388645bf1786892d
     name: diffutils
     evr: 3.6-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/d/dracut-049-233.git20240115.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 582719
     checksum: sha256:21cebc2005d7aa0b6cd45f1a5455ac85f75399b8d3f2a38de3f47585f2200acd
     name: dracut
     evr: 049-233.git20240115.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/e/e2fsprogs-1.45.6-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5675423
     checksum: sha256:1c0771ea038777ecf84ba31cba0c3d221d39e351c1a6e7967857977c1949c792
     name: e2fsprogs
     evr: 1.45.6-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/e/elfutils-0.190-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 9288737
     checksum: sha256:54fe49a6fd4f87d6fd594b62c465105fc3efab05a1ffcc216f053c277ab619bf
     name: elfutils
     evr: 0.190-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/e/emacs-26.1-13.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 44386554
     checksum: sha256:302fc2e7df4c6912cd349b739fde793bcc9f785b260d1ac406f37a5012b47512
     name: emacs
     evr: 1:26.1-13.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/e/expat-2.2.5-17.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 8345318
     checksum: sha256:41de03fcbf3a8f7fa42e7017058ae0186e98a0e448ce01772de7af0a856a749d
     name: expat
     evr: 2.2.5-17.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/f/file-5.33-26.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 899551
     checksum: sha256:1bdcfa5032e3ef5ff5f9f72233b6c9c67c0c7ff994a04df131d3b64b213b99cb
     name: file
     evr: 5.33-26.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/f/filesystem-3.8-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 37286
     checksum: sha256:113b7c5e28cc1d44e21c564c17d8c592a3f8a20b4c268cdaad6a407dee4d1540
     name: filesystem
     evr: 3.8-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/f/findutils-4.6.0-23.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 3831527
     checksum: sha256:28510e1bb0c939d1b945f889611cf572e03ee18faaa5bff6f0ad203fd696fb29
     name: findutils
     evr: 1:4.6.0-23.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gawk-4.2.1-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 3036497
     checksum: sha256:fac4ea2cb712ff3f0dd723d6eec358e051040592492b5cf6bd66354b8a09f143
     name: gawk
     evr: 4.2.1-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gcc-8.5.0-26.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 65714976
     checksum: sha256:12ebb9cdefb5f8c68bbce3eb469440d26f0d64de958751f4916328ed02522ed2
     name: gcc
     evr: 8.5.0-26.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gdbm-1.18-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 966590
     checksum: sha256:e91abeb46538fc264936c0eed825c28eab9eef47288c9eb1d2d4d078bccad5d1
     name: gdbm
     evr: 1:1.18-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gettext-0.19.8.1-17.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 7264423
     checksum: sha256:114be9b072a7726f2ac557fda6b8a86254ae3b7ed984ed14cfa7733bea9005d4
     name: gettext
     evr: 0.19.8.1-17.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/glib2-2.56.4-165.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 7127086
     checksum: sha256:0d418524f04a24e2357b26d4107424780acca901a1575a7a5cbf178b2aa1458c
     name: glib2
     evr: 2.56.4-165.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.28-251.el8_10.16.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 18487094
     checksum: sha256:f988b183ac97142187843e95dab32f9d7bc8bce3723c80a535a3dfdabba08a44
     name: glibc
     evr: 2.28-251.el8_10.16
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gmp-6.1.2-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2430007
     checksum: sha256:0be11faec5810961b3b5b2f0e8a54c4628b62bb2bec4e282f47682c4be0cef64
     name: gmp
     evr: 1:6.1.2-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gnutls-3.6.16-8.el8_10.3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5774773
     checksum: sha256:e3dc1e166a626f8ff303c9d9a260d4a1ac68cd2a62d28bfec51d6b1aa3670053
     name: gnutls
     evr: 3.6.16-8.el8_10.3
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/grep-3.1-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1412532
     checksum: sha256:c5d8342de1536365d5ccb340a4a381b40529eb98a6866981df956e4adc2727ac
     name: grep
     evr: 3.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/groff-1.22.3-18.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 4272813
     checksum: sha256:3d70ed8c7784143119218a32b413fa210c04f380018c6c801a33f7e33885ed19
     name: groff
     evr: 1.22.3-18.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/grub2-2.02-165.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 8327584
     checksum: sha256:01c652d9a48600b8a77f44c9d93878db5f5fffd3b4f0f9988fae892020feeb56
     name: grub2
     evr: 1:2.02-165.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/grubby-8.40-49.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 233771
     checksum: sha256:cf243444b0a597051b63da2c3fc86a89d6e187549f0765edd2129ba8ab48f48c
     name: grubby
     evr: 8.40-49.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/g/gzip-1.9-13.el8_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 822025
     checksum: sha256:cca21983255b0d999938c7a42a43d6402ab4bce1dbd058a16d6c4a2e6b95d763
     name: gzip
     evr: 1.9-13.el8_5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/h/hardlink-1.3-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 27360
     checksum: sha256:f6f9b604b76e2871dabd14205cb7ed0c5abcdb0e597c1da4cd1c310f7567c7d3
     name: hardlink
     evr: 1:1.3-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/j/json-c-0.13.1-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 647075
     checksum: sha256:f68a400c6a103bf4c37e1c43c2716386beb087519b21204b8b2dd1f85392d528
     name: json-c
     evr: 0.13.1-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/k/kbd-2.0.4-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1073844
     checksum: sha256:9ccad26b460609bc75dfe8795f72dbdcc9fdd08529de1398a7d2a205d6d20ad3
     name: kbd
     evr: 2.0.4-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/k/kernel-4.18.0-553.54.1.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 138634600
     checksum: sha256:d0cfc85108f3424439bdec96ba6ee20360f0b5c43efc76dad9c0b0bec7d181db
     name: kernel
     evr: 4.18.0-553.54.1.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/k/keyutils-1.5.10-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 103686
     checksum: sha256:8b3c331a0500880d8cd6e5ccdcb7e6600e5be5fbfe4a7a203b4acc0dbe09a562
     name: keyutils
     evr: 1.5.10-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/k/kmod-25-20.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 584947
     checksum: sha256:3df9490dc2b5146a1e0953d254540d64b7e0c304c52ebd64baf2eeb78eae70bd
     name: kmod
     evr: 25-20.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/k/krb5-1.18.2-31.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 10383931
     checksum: sha256:1c1468efcb7c58f7e40727e45deb6f7d30b8ddb3acaa192a15807af8f1fdfc22
     name: krb5
     evr: 1.18.2-31.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/less-530-3.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 381600
     checksum: sha256:3a3fb5787be53264b5619eda709d8dc7a0f2eb8bfd658569d6543baff36e7366
     name: less
     evr: 530-3.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libarchive-3.3.3-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 6570219
     checksum: sha256:97e61fdb02920262ab2c2506465dca8492b33050561d3d981ed1065083166c3e
     name: libarchive
     evr: 3.3.3-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libcap-2.48-6.el8_9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 208927
     checksum: sha256:b9a60d012b2102ff8df1d03e949c13ffe1090e11a00422c16992cb897f1c50da
     name: libcap
     evr: 2.48-6.el8_9
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libcap-ng-0.7.11-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 81626
     checksum: sha256:1267aec0cd63a1487a9a103120656bd62a1f8ec64552e6438f10e58d086fe82c
     name: libcap-ng
     evr: 0.7.11-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libcroco-0.6.12-4.el8_2.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 500156
     checksum: sha256:327dbd1a9f48341e8f391c3ac809cfe68ea8f23091949fe92b810eefa015aa20
     name: libcroco
     evr: 0.6.12-4.el8_2.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libdb-5.3.28-42.el8_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 35289360
     checksum: sha256:b499193ca56c182b457f0fd6943f3a210f707997f722f95c20ca7e4a2361fba5
     name: libdb
     evr: 5.3.28-42.el8_4
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libedit-3.1-23.20170329cvs.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 525171
     checksum: sha256:901bf3148d874bf17878d56ecbb524d1752a144164ca9c92891c181a3fccbfc2
     name: libedit
     evr: 3.1-23.20170329cvs.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libffi-3.1-24.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 960384
     checksum: sha256:5f1ecf2dd9b162c2d2d526918ac1a9d5f02d4f02dea1478f7cb25538bd0c7214
     name: libffi
     evr: 3.1-24.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libgcrypt-1.8.5-7.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2792226
     checksum: sha256:99734fb837bc7026c65eb15c0525f68288e73672fc2a3d583c3279786e47a13d
     name: libgcrypt
     evr: 1.8.5-7.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libgpg-error-1.31-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 921864
     checksum: sha256:6d5ca569e833217f8213e6607868d64a9c86c89770ecf3c4f1f260496461600e
     name: libgpg-error
     evr: 1.31-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libidn2-2.2.0-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2117426
     checksum: sha256:1fe11bb60d0913eb3c306a2092453c7079fcb71f1a0a5e5da3a51c4239111bfd
     name: libidn2
     evr: 2.2.0-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libkcapi-1.4.0-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 368458
     checksum: sha256:d6c0b8ea52682c8ed685ef44ded88c036f474a26a9107a47b23c20dd83b296d7
     name: libkcapi
     evr: 1.4.0-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 147827
     checksum: sha256:db3d53543d5caab48a6c0e582a8a5b4a00ae7a6b268e2b1231ce9de80f89ddd9
     name: libnsl2
     evr: 1.2.0-2.20180605git4a062cf.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libpsl-0.20.2-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 9190060
     checksum: sha256:80065f45ecdd72e97329a55786a7186b19204df1f485566eadf2e5810ff270df
     name: libpsl
     evr: 0.20.2-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 443269
     checksum: sha256:79048b406a5ecf7b97286cd72c5ab8f84f91174f1741db66b0e1a24a7de66113
     name: libpwquality
     evr: 1.4.4-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/librtas-2.0.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 104755
     checksum: sha256:75bfe42fde48fabf15d5209b0e03d3f84612278cc13c5355b8a3107f4d50a66b
     name: librtas
     evr: 2.0.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 654889
     checksum: sha256:322f0b9e2a909001e5e688b8ad52a5e6361ab350fa4fced3f446a6d1a3f2074a
     name: libseccomp
     evr: 2.5.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libselinux-2.9-10.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 355220
     checksum: sha256:2f61feb51798629d4f7b78130e68eb2516463da41d6e7b64d82d28d17355b3f1
     name: libselinux
     evr: 2.9-10.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libsemanage-2.9-11.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 267435
     checksum: sha256:0e9bc0dd2ddcf5e8e8f734b32c7a3c93165060ef5b2f5910713984cea71e349f
     name: libsemanage
     evr: 2.9-11.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libsepol-2.9-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 562616
     checksum: sha256:98d64b940c64159d3e3a18e1b25cd7b9018563db56c9ecdc7d4f4481e4dde0dc
     name: libsepol
     evr: 2.9-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libsigsegv-2.11-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 463284
     checksum: sha256:a139e44850d9210e2a662e676dd57a6a40323b1744a14be7a87221f8e36cffe5
     name: libsigsegv
     evr: 2.11-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libssh-0.9.6-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1151415
     checksum: sha256:a04fb32a5bdaf33053918c3c931891fe7415a8ace08069b74d055931413056eb
     name: libssh
     evr: 0.9.6-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libtasn1-4.13-5.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1968290
     checksum: sha256:c8ab521d0a15d78469b5525143fb7a5edb7db046a6eee1bdad3a51c4125ec852
     name: libtasn1
     evr: 4.13-5.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libtirpc-1.1.4-12.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 560689
     checksum: sha256:6bfcac057ab526f43b562f42b471f98c563456817bcda85cba058becccbee71b
     name: libtirpc
     evr: 1.1.4-12.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libunistring-0.9.9-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2058209
     checksum: sha256:41bf7f587637bc262a39720a9af0bd6c0132f75e421e69903f5418870335df8e
     name: libunistring
     evr: 0.9.9-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libutempter-1.1.6-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 32789
     checksum: sha256:cba58a16a506c2de446105f7b2c3e765d34a02941ea46d3ff03ed20c624f861f
     name: libutempter
     evr: 1.1.6-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libverto-0.3.2-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 397339
     checksum: sha256:b6b19f09348381edcd692dda7c260a728d09c65f071d68ffed18de8f12eed403
     name: libverto
     evr: 0.3.2-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libxcrypt-4.1.1-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 229519
     checksum: sha256:d9803b5dd6cdbb4fd977258092cb50c48c8e28f3e3b4a0d6056c093983e17b29
     name: libxcrypt
     evr: 4.1.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/libxml2-2.9.7-19.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5483351
     checksum: sha256:7e50cdc6eb992d219955bbff31a2647a4ed00b088ad3fa16954947c3afd2c62a
     name: libxml2
     evr: 2.9.7-19.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/lua-5.3.4-12.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 437265
     checksum: sha256:764fa61f3a6678bf93d94351468e49863176420688ab4e8c1aa6a5eb84ecf23d
     name: lua
     evr: 5.3.4-12.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/lvm2-2.03.14-15.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 3182486
     checksum: sha256:eb51bc7200bf3af803093b3b61c543aae9560c36999aeca1304cd718b8bbe453
     name: lvm2
     evr: 8:2.03.14-15.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/l/lz4-1.8.3-3.el8_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 343953
     checksum: sha256:5952931f1ccd36d3db5bf1bb007966056e5fde6569a8d2da8e91b38bd9f41d3b
     name: lz4
     evr: 1.8.3-3.el8_4
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/m/make-4.2.1-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1446894
     checksum: sha256:19a4dbbf35f5ea28cfc2fd3f43ab01093f456804d1f94364121c025155f01112
     name: make
     evr: 1:4.2.1-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/m/memstrack-0.2.5-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 63665
     checksum: sha256:1eeeb865142626c458cf9659c88b400b9cb2cc9416e46baf740dff32f92f1cbe
     name: memstrack
     evr: 0.2.5-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/m/mpfr-3.1.6-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1153938
     checksum: sha256:1351024682b450c80c268a6132373bef0b7b35289d791f0fcca9385cfe3ddce4
     name: mpfr
     evr: 3.1.6-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/n/ncurses-6.1-10.20180224.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 3422193
     checksum: sha256:6fcd8a8bc7eca36c65368df740a5760961740d0c34342cdb0eb23b54799948a4
     name: ncurses
     evr: 6.1-10.20180224.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/n/nettle-3.4.1-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1473768
     checksum: sha256:6c9f6c3e1a7d9bfc9b824cb4ce6e48e13698cea554504628564e0b4fdcfa5ac3
     name: nettle
     evr: 3.4.1-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/n/nghttp2-1.33.0-6.el8_10.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1589583
     checksum: sha256:9cf44c14ea0a908468049f7d301662e5ee1e0769b0ad144cae10b2a9158c2cbe
     name: nghttp2
     evr: 1.33.0-6.el8_10.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/o/openldap-2.4.46-21.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5853007
     checksum: sha256:42a8826001f6a49c1385746f1c5ef3967c3f15fe6fa510fe001d5a232732661a
     name: openldap
     evr: 2.4.46-21.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/o/openssh-8.0p1-25.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 3031156
     checksum: sha256:7a69d14debfacb701f4c71f9a17d41500d225397e3879f8027f729a9d4a259ab
     name: openssh
     evr: 8.0p1-25.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/o/openssl-pkcs11-0.4.10-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 520347
     checksum: sha256:a737e7fe890c5f53c1bc0c5925375791d8890f9d51c4a509091b41efa3f92861
     name: openssl-pkcs11
     evr: 0.4.10-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/o/os-prober-1.74-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 55171
     checksum: sha256:0577008638e1644fed230d55b221b485e6cdc702cda9c27cf74ab7adcb8b8f00
     name: os-prober
     evr: 1.74-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/p11-kit-0.23.22-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 909983
     checksum: sha256:9dece924ffd6e5698e7cb865f01976d7786b8c3cc65e743cf9ce3a856baff95e
     name: p11-kit
     evr: 0.23.22-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.3.1-36.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1166826
     checksum: sha256:5a73a9d6ffbc3fa84853486a233e95765189dd0bf7b18059f2b8e763bfc8591f
     name: pam
     evr: 1.3.1-36.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/pcre-8.42-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1617186
     checksum: sha256:6d9f5c6ed81e5975723caa998de058df638dfadc33cc856d3a97c69db3180cb5
     name: pcre
     evr: 8.42-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/pcre2-10.32-3.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1671843
     checksum: sha256:bd60f4e4bf7bbadef2ff329112b5267da38a271af3c88fe53c57499c402c6670
     name: pcre2
     evr: 10.32-3.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-5.26.3-422.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 14612935
     checksum: sha256:846caf250e9bc506d779db0a1f94c181cb1278db67a89cfeb8ad9863cf8475a3
     name: perl
     evr: 4:5.26.3-422.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Carp-1.42-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 39410
     checksum: sha256:6e54cfe6173d114d79ad787616debfcd361215cb706a073849e5b725e9d602f5
     name: perl-Carp
     evr: 1.42-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Data-Dumper-2.167-399.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 133858
     checksum: sha256:693f45422bea04068b74e2006b6fe83ab28717c811a5010bf03d6dbc1971deac
     name: perl-Data-Dumper
     evr: 2.167-399.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Digest-1.17-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 22585
     checksum: sha256:ec3cc9dded5debede94ab5a1ac9635b9ce47378bdb759a45d6342ee1a1a3b3ff
     name: perl-Digest
     evr: 1.17-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Digest-MD5-2.55-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 60640
     checksum: sha256:e03a9fead12685a2190d6b01a1a81809a7bc7bdcba52dc8f3d9c099af12d0c8e
     name: perl-Digest-MD5
     evr: 2.55-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Encode-2.97-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1909992
     checksum: sha256:ccdb4f8262ca5564d92873e502108424e84ebc1fe2f87303c3f83abeaaa8b9e4
     name: perl-Encode
     evr: 4:2.97-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Exporter-5.72-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 30797
     checksum: sha256:4ebd569f83d0a04406c2784d4dcc06bc3aec02c47fcc315b2408b07f9cb6d7cb
     name: perl-Exporter
     evr: 5.72-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-File-Path-2.15-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 44093
     checksum: sha256:d067cc6c5f63792fd0167bee1235c2e7b041d0724383ac65d1a275c92e60ee7d
     name: perl-File-Path
     evr: 2.15-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-File-Temp-0.230.600-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 89704
     checksum: sha256:aef94fc3f0fdc16f4332c1d44c05bf96abd821a35a5645dc7df98159563fde23
     name: perl-File-Temp
     evr: 0.230.600-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Getopt-Long-2.50-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 55481
     checksum: sha256:78e26ca8558531b08df38b63ff09b15a1237f57693cfb191dff6b123b52ad462
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.074-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 94643
     checksum: sha256:ee584d582dc268ceefd1c334f19178df24d15e2bbf3fc4db3408d8baf7ba1156
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.39-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 60059
     checksum: sha256:474c2d5388faea1a2a958d803754276dd99105a5e446200aebca09e0cb16445e
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-MIME-Base64-3.15-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 28234
     checksum: sha256:ed1d5e3edc2c0e83cfe4f4db09ffcff50b6a70d91ccac2856b2024c9261351f9
     name: perl-MIME-Base64
     evr: 3.15-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-PathTools-3.74-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 137742
     checksum: sha256:07efbd3dd8efa238a61845f2e8328836208344c58b3cde763ed726ad9f66e53d
     name: perl-PathTools
     evr: 3.74-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 21369
     checksum: sha256:c7d6b9fd27c89bb9607dc6870be25816af5f75a98955539570250077f3e13c58
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 170889
     checksum: sha256:300bdca3d858f534ad829cd9b8c762c5b34cfad11c31d70ee6beb9035f07cbeb
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Pod-Simple-3.35-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 292502
     checksum: sha256:865ee9e5c0dfb5ad3cd83eeb9b35082d6d51b1c9a18e80e6e4121710f6321663
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Pod-Usage-1.69-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 74242
     checksum: sha256:eafe281a2099a0dc407427cfa56696f460a0635f34e2233c019ae0bc0fba245b
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 103833
     checksum: sha256:ffb0c86b10d1103123df63cc0328d09315db6b03802f2614a96fdd7232444803
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Socket-2.027-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 61493
     checksum: sha256:f4a44ab8183b9172652f9c749a184410b5067c8cc6656a35c4eb12c6c4cb8a52
     name: perl-Socket
     evr: 4:2.027-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Storable-3.11-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 212600
     checksum: sha256:e5b897cf73b34d9f121366108a56d4c9b3cc5b4feae9216d06a1ea9faadb8a1c
     name: perl-Storable
     evr: 1:3.11-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Term-ANSIColor-4.06-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 63153
     checksum: sha256:6c78167c38a6fcc475392ccb60dddba5ec7aea6d4c9ccc8fdaea6066611a3c23
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Term-Cap-1.17-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 22600
     checksum: sha256:2953646cb9447ea6be598bbf750521016967d09cbee580e7177fb14b1fec49e1
     name: perl-Term-Cap
     evr: 1.17-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 19141
     checksum: sha256:04dce7752e55622eb65ff504b4f43190e1104fd7bd0fa6f7d0a08b99c35f6827
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 30141
     checksum: sha256:ee70aff3a8052cd9a2c42332a8514883e0453f1cc4b51283a8f0213fd2a50e6c
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Time-Local-1.280-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 52203
     checksum: sha256:37a06155836500c22854a0ed2cd1e19e2cb9464eafef8e2b72159923a13b9aa7
     name: perl-Time-Local
     evr: 1:1.280-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-URI-1.73-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 126236
     checksum: sha256:dad920c0cd599360aff44efb33d8de6245b937dd296b011c645db1464fcc4ce9
     name: perl-URI
     evr: 1.73-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.25-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 51863
     checksum: sha256:26df107448834f5b2def4c6cd609298c6bbbfe3220f8077664158f2a20581f73
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-constant-1.33-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 32690
     checksum: sha256:976f9c6ee5780e4b70a1a712516ff0e1c956ebb47bcd2616fbbb536520bbc328
     name: perl-constant
     evr: 1.33-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-libnet-3.11-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 106574
     checksum: sha256:dc91b0b1230e700b03f6bf9b67e7e1888a40fb3cba04407be800ebe03b3f6632
     name: perl-libnet
     evr: 3.11-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-parent-0.237-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 27591
     checksum: sha256:08815783344cfa0bf276838b3ed36e3df7c6d854a350c6515f8585d2aceef5f6
     name: perl-parent
     evr: 1:0.237-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-podlators-4.11-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 146297
     checksum: sha256:5400b164b06ffb22a71c9f784bb8d2a8ca1f337a0444eb7072383fd5c0b4cc50
     name: perl-podlators
     evr: 4.11-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-threads-2.21-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 129508
     checksum: sha256:d87b4593b6b3aa2edf6caed1693b5f20af1e9998cfd2cd94246f30bb15257653
     name: perl-threads
     evr: 1:2.21-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/perl-threads-shared-1.58-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 116865
     checksum: sha256:f4d768aa34f6bfbe9985856bf5188c2dd7b02f99b415343ef135335d0e86e8a1
     name: perl-threads-shared
     evr: 1.58-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/pigz-2.4-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 111085
     checksum: sha256:25eb0a7a95c2f45dddec4349fe6c5e81399859295954d44f0fbdfd849d593d06
     name: pigz
     evr: 2.4-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/pkgconf-1.4.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 300577
     checksum: sha256:2bbbbb503f27488cc66f935cd31a14f1eb01cd9e5fb9d52260bacdea663abb1a
     name: pkgconf
     evr: 1.4.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/policycoreutils-2.9-26.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 7122315
     checksum: sha256:c3fa01ec896e6e30d1a27244a0c0dfab3ea733cfc2c519698899cf1c0dfda03f
     name: policycoreutils
     evr: 2.9-26.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/popt-1.18-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 596391
     checksum: sha256:bd40809646317352c305974bc1204064b1492de90718b61b738548307cde1ac4
     name: popt
     evr: 1.18-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/procps-ng-3.3.15-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 948787
     checksum: sha256:f7c6882f91e993ebdc97259a7ef0fe42dd9f98b34226bb8ee89b4c8a8d778abd
     name: procps-ng
     evr: 3.3.15-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/publicsuffix-list-20180723-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 86231
     checksum: sha256:696b5b556ecdfd7649e9275e20e5ff7b191b30631e11dadc93853de860f5ed4c
     name: publicsuffix-list
     evr: 20180723-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/python-pip-9.0.3-24.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1380608
     checksum: sha256:0c18dcaadf6e9596e2b939ae9cc75db12df7919a01a204f314df315e384b0d4a
     name: python-pip
     evr: 9.0.3-24.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/python-setuptools-39.2.0-8.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 868530
     checksum: sha256:cd563238ca4ec7c288874e42d1506337e4917620ed83b1e4a2aec2fb6a5ea770
     name: python-setuptools
     evr: 39.2.0-8.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/p/python3-3.6.8-69.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 19223254
     checksum: sha256:4578b972df16aa25dae9170d339d86792c59612f29e0726ead0107ed7347ba3a
     name: python3
     evr: 3.6.8-69.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/r/readline-7.0-10.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2937518
     checksum: sha256:d35c049106cb1377d5c13f2d8dd508c035bdbcc8b0cf15c9fa41dad0c946c89b
     name: readline
     evr: 7.0-10.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/r/redhat-release-8.10-0.3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 58701
     checksum: sha256:9b36cf3d7c42a8663017a44e4ae42cfcea0837dc416746f26238b1284a291230
     name: redhat-release
     evr: 8.10-0.3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/r/rpm-4.14.3-32.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 5269921
     checksum: sha256:b43436849f8b9fa3dfe8e42e87e814906f0cae191f9d159ea24ec9732d379d58
     name: rpm
     evr: 4.14.3-32.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/sed-4.5-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1358944
     checksum: sha256:f455a908d552d720431cbef8af08ee44004b6d7b3d1a1768de99c117a718c8c8
     name: sed
     evr: 4.5-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/selinux-policy-3.14.3-139.el8_10.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1934638
     checksum: sha256:da1784cbc92552eec7bc06125079a729d8bf62a53e2378f6d67a9f6705e101b8
     name: selinux-policy
     evr: 3.14.3-139.el8_10.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/setup-2.12.2-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 220230
     checksum: sha256:72f87a1c0c92c9486bdb3748db880281fcc1f947bbedb99edbcebf189e4a5c40
     name: setup
     evr: 2.12.2-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/shadow-utils-4.6-22.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1845120
     checksum: sha256:140a4273738ea9cfd1fc5627ebd66ad1696a5e3c959092b41bf5dc6d7657d8a6
     name: shadow-utils
     evr: 2:4.6-22.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/shared-mime-info-1.9-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 644720
     checksum: sha256:b070925e9e0d4824b3c0ed86bad64f77daf954ec359260789fe8f8150ef402c6
     name: shared-mime-info
     evr: 1.9-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/sqlite-3.26.0-19.el8_9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 23592377
     checksum: sha256:d4bd6ea502814941a714ab1f40e87d8f48fc4a362b344ca928f3c2f514fdf024
     name: sqlite
     evr: 3.26.0-19.el8_9
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/s/systemd-239-82.el8_10.5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 9161850
     checksum: sha256:a20ae7bd2f13fd756b2389ec6ba6f84e6a9be28df01b5a7d04dab93b492a0eab
     name: systemd
     evr: 239-82.el8_10.5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.30-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 2169236
     checksum: sha256:53ae8ab2f98cb36c9d7e3830a7a8d6a9897707bf3d0f0c6805282f88ca6e23f7
     name: tar
     evr: 2:1.30-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/t/texinfo-6.5-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 4544531
     checksum: sha256:94881acbdc6de2e2e22c7fac12ca732da89b2b6d245ca9f8a5810387090ccb76
     name: texinfo
     evr: 6.5-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/t/trousers-0.3.15-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 4722437
     checksum: sha256:ad79eab11673ac2f172276a993d98f2bf98c77728863f656d7cc0ab595d5b593
     name: trousers
     evr: 0.3.15-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 946701
     checksum: sha256:2f0ba51d371713287a690d9d1635b534113258aa2571862603d52870c1c8b60d
     name: tzdata
     evr: 2025b-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/u/util-linux-2.32.1-46.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 4816801
     checksum: sha256:3fb688481dd062d917d8119cd64582a9e6ffa6736a6dbbf956d038a9115c6004
     name: util-linux
     evr: 2.32.1-46.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/w/which-2.21-20.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 171457
     checksum: sha256:70aca3ef4713172514dbe5334bd56b29a988e736211e946219f5d965b31eebce
     name: which
     evr: 2.21-20.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/x/xz-5.2.4-4.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1077113
     checksum: sha256:7914b320eefa2db6dad68e5f01e99f8e661072a1f13acb3d19cba8c1295ae40a
     name: xz
     evr: 5.2.4-4.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/z/zlib-1.2.11-25.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 565905
     checksum: sha256:d632ef6e133e08c97258fdee1642a3c24106aa03f80e3c190a9d24be8669da7f
     name: zlib
     evr: 1.2.11-25.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/baseos/source/SRPMS/Packages/z/zstd-1.4.4-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-ppc64le-baseos-source-rpms
     size: 1973262
     checksum: sha256:df48591f05ff68cbf8dc8ad48c814e14ed39866511b14933a1c0ab1c3fec5469
     name: zstd
     evr: 1.4.4-1.el8
   module_metadata:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/repodata/1974fe8d3bf9dd90e3cc655ca5534b995417417e10c51e9daf02fbffe0726967-modules.yaml.gz
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-ppc64le-appstream-rpms
     size: 704057
     checksum: sha256:1974fe8d3bf9dd90e3cc655ca5534b995417417e10c51e9daf02fbffe0726967
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/c/container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 72367
     checksum: sha256:dacec63c6fc997fc110480f94a42dde032c3ba34c228807ba967c4f6f78a92fa
     name: container-selinux
     evr: 2:2.229.0-2.module+el8.10.0+22931+799fd806
     sourcerpm: container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/c/cpp-8.5.0-26.el8_10.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 10931332
     checksum: sha256:059c9b50f00d1774bbc49423fbd0931237621e2b6c611da15a34f06a1bd67bf0
     name: cpp
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/d/delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 5587274
     checksum: sha256:5882a0cfa7eb18396621d8783f062a506ae6977d9a5a29e9c05ae7e5fd93dc8a
     name: delve
     evr: 1.24.1-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/gcc-8.5.0-26.el8_10.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 24579364
     checksum: sha256:0599a0013785a5621abfb10e4b743e9f60314a243cffe90c65c4acc6ed0f0773
     name: gcc
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/git-2.43.5-2.el8_10.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 94608
     checksum: sha256:5ae3009e2b46a01ed2d992a23523b2dba102ec01b3ffb018d5c74015754244ea
     name: git
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/git-core-2.43.5-2.el8_10.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 11623992
     checksum: sha256:b74d47407af0f2affa03899b4d2375dfb857869cbbe87f142eae7ef61afc0c6b
     name: git-core
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/git-core-doc-2.43.5-2.el8_10.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 3214228
     checksum: sha256:28198b6eaefd6c9742fad921b70285b68c65fc6e8f2466e6211d32528b15bfd0
     name: git-core-doc
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 15790
     checksum: sha256:a1324422aff2247fbaa592a144e2d9c9b1721378cc38690dac8b7a0dfa04dc14
     name: go-toolset
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 780730
     checksum: sha256:d0db4eb4c68484fcfa0442b8232b836f3850a60d7da889653a3c99a7c8e37e18
     name: golang
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/golang-bin-1.23.6-1.module+el8.10.0+22945+b2c96a17.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 76184230
     checksum: sha256:63c24307dbaeae9e5cdedb38d32bdb86aa46739a54e41aff44ddcb043eea08d3
     name: golang-bin
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/g/golang-src-1.23.6-1.module+el8.10.0+22945+b2c96a17.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 12613790
     checksum: sha256:654ef2cb3e067bceb9ea88f1751ebe1987c787242db65198c6fc25469f1aba06
     name: golang-src
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
     sourcerpm: golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/i/isl-0.16.1-6.el8.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 861300
     checksum: sha256:67e906b7bf52efc411fcf86568a90d6bf580242a7dc2b2fff813f0864492c7ea
     name: isl
     evr: 0.16.1-6.el8
     sourcerpm: isl-0.16.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/l/libmpc-1.1.0-9.1.el8.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 62440
     checksum: sha256:230146e73dbaa1a259c2d8f1fbb10026c1726ebf2f14ef7e7e7957eb27b97ae9
     name: libmpc
     evr: 1.1.0-9.1.el8
     sourcerpm: libmpc-1.1.0-9.1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/l/libxkbcommon-0.9.1-1.el8.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 118548
     checksum: sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072
     name: libxkbcommon
     evr: 0.9.1-1.el8
     sourcerpm: libxkbcommon-0.9.1-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-Git-2.43.5-2.el8_10.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 80852
     checksum: sha256:d0eee09820f491430ce59a2a82d39182c2231a4a7880f9faeaee4163dc008d4f
     name: perl-Git
     evr: 2.43.5-2.el8_10
     sourcerpm: git-2.43.5-2.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 388290
     checksum: sha256:290312d4dd2d24f0c42235a50512d5a7d23018a0ef12eb54907aa8f88cc22fb3
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 41200
     checksum: sha256:ea22b60430f762e2b8e2d5697522af1aa937ea0b933c6dbe5b5a8ca4f2b7dbd6
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/Packages/x/xkeyboard-config-2.28-1.el8.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 801000
     checksum: sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806
     name: xkeyboard-config
     evr: 2.28-1.el8
     sourcerpm: xkeyboard-config-2.28-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/a/acl-2.2.53-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 83124
     checksum: sha256:a22d3f42d7a49ab2e8e7d1c831a80fca159a649a8969ab0617ab93b24df5fa20
     name: acl
     evr: 2.2.53-3.el8
     sourcerpm: acl-2.2.53-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/a/audit-libs-3.1.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 127692
     checksum: sha256:6c2119e3be28775cdc82b6e95ee9f3f7e4d420b75aa99ca1ab953bc6af863b57
     name: audit-libs
     evr: 3.1.2-1.el8
     sourcerpm: audit-3.1.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/b/basesystem-11-5.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 10756
     checksum: sha256:b9584e6823ffe9ccf79282bd57ee076a1e3a71c4c1020a20b5e1975141a50f14
     name: basesystem
     evr: 11-5.el8
     sourcerpm: basesystem-11-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/b/bash-4.4.20-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1622480
     checksum: sha256:3fca78c61e72c8ed21a8fd123ccaf253c86beebc6196b44aa3e029871e22b8c4
     name: bash
     evr: 4.4.20-5.el8
     sourcerpm: bash-4.4.20-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/b/binutils-2.30-125.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 6049096
     checksum: sha256:047fc8bd5bb6def766c46397c8a535faa3634a54832edb301c4d27dd92400cc0
     name: binutils
     evr: 2.30-125.el8_10
     sourcerpm: binutils-2.30-125.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/b/brotli-1.0.6-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 330860
     checksum: sha256:267858a95e543459a0cd683e641955d7c04c13bcda830c5f7db5a0529077428a
     name: brotli
     evr: 1.0.6-3.el8
     sourcerpm: brotli-1.0.6-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.6-28.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 49384
     checksum: sha256:dc8a416dd88d361bbf9e324903ebbd75e79fb856fc0db0769e7bab96b3212364
     name: bzip2-libs
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1006212
     checksum: sha256:5b97c63d4978f82a8d73cb83c81c438d69309bc929d35c6bebf5868f128da13f
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-80.0.el8_10
     sourcerpm: ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/chkconfig-1.19.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 203364
     checksum: sha256:35286c6cd8f5e98140b95c625b23cec30faf48fcc59cc988f9228f6d857cf287
     name: chkconfig
     evr: 1.19.2-1.el8
     sourcerpm: chkconfig-1.19.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/coreutils-8.30-15.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1274536
     checksum: sha256:c7e02ffc3471e2d7ea8fbf19f1800742eeb0ea729ab6ec5796b1c9e1f65c1ef6
     name: coreutils
     evr: 8.30-15.el8
     sourcerpm: coreutils-8.30-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/coreutils-common-8.30-15.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2092844
     checksum: sha256:f916e02672303e038ed39fee2bba94096db4d87d9ea061b1aba0e95930ecc28f
     name: coreutils-common
     evr: 8.30-15.el8
     sourcerpm: coreutils-8.30-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cpio-2.12-11.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 272056
     checksum: sha256:b2f076bf0b561c06b78adeb78be388d74606a8112530161073bf9c877eb1f744
     name: cpio
     evr: 2.12-11.el8
     sourcerpm: cpio-2.12-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cracklib-2.9.6-15.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 95532
     checksum: sha256:9cf2e24fdbe89f25b8283291fd3fcaf73ca60554bbf5767932c38882cdd0e3c4
     name: cracklib
     evr: 2.9.6-15.el8
     sourcerpm: cracklib-2.9.6-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-15.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 4144880
     checksum: sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d
     name: cracklib-dicts
     evr: 2.9.6-15.el8
     sourcerpm: cracklib-2.9.6-15.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/crypto-policies-20230731-1.git3177e06.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 65848
     checksum: sha256:05e1adb9bab2ce597e4ed4c6711f6000f0a5a56e1a85ba1a9098540633c144e7
     name: crypto-policies
     evr: 20230731-1.git3177e06.el8
     sourcerpm: crypto-policies-20230731-1.git3177e06.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/crypto-policies-scripts-20230731-1.git3177e06.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 86232
     checksum: sha256:06b11ba8e168d524a902768b07b42e1cb7a6b502de447d504d8c7b59ca7584ac
     name: crypto-policies-scripts
     evr: 20230731-1.git3177e06.el8
     sourcerpm: crypto-policies-20230731-1.git3177e06.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.3.7-7.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 500812
     checksum: sha256:acb20a87af67ceb58dfa295e50c06674511c62d2499d3076a44390d7e3ce0f85
     name: cryptsetup-libs
     evr: 2.3.7-7.el8
     sourcerpm: cryptsetup-2.3.7-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/curl-7.61.1-34.el8_10.3.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 362392
     checksum: sha256:9982a2c567a50bdadee162a853d77b6c556fb4d2b2483c9c21197ed8af706327
     name: curl
     evr: 7.61.1-34.el8_10.3
     sourcerpm: curl-7.61.1-34.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-6.el8_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 126324
     checksum: sha256:2482abf921c21e313577829dc14a7a89693228a6e39d7558a400b056aa45efb9
     name: cyrus-sasl-lib
     evr: 2.1.27-6.el8_5
     sourcerpm: cyrus-sasl-2.1.27-6.el8_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dbus-1.12.8-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 43292
     checksum: sha256:5426567ee5fe19e84dbe8c06c73602d588b193e6bb77b2becc31c773fafeb469
     name: dbus
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dbus-common-1.12.8-26.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 48092
     checksum: sha256:3093c5c1356bc92805a6821f9242a7fc947bbaa1ff427d310dc397f4ea38ef3e
     name: dbus-common
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dbus-daemon-1.12.8-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 247064
     checksum: sha256:e2f321553b0a92fee5637e5837a35dbe7baf2b4b4f7fe9b2f1a9b66c8a6cdb85
     name: dbus-daemon
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dbus-libs-1.12.8-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 189528
     checksum: sha256:57a38545641fdd14a7887d187fe147d2ca0a22e5a292b9ac5daa2018cc67ed7e
     name: dbus-libs
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dbus-tools-1.12.8-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 88560
     checksum: sha256:373d4320fbcb4e823fdf5ad07dbb39805a71a249429e1eff0575bc336ae5634e
     name: dbus-tools
     evr: 1:1.12.8-26.el8
     sourcerpm: dbus-1.12.8-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/device-mapper-1.02.181-15.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 388100
     checksum: sha256:195756419b17c95c3e22bff3bf7e868ab98447c7ea10683e9cc33baa41da8b56
     name: device-mapper
     evr: 8:1.02.181-15.el8_10
     sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.181-15.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 421184
     checksum: sha256:b929c1c109c892a6bc379bfd0afd8f117100950a9f3b9037ee43e7d9ba025dc8
     name: device-mapper-libs
     evr: 8:1.02.181-15.el8_10
     sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/diffutils-3.6-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 367420
     checksum: sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce
     name: diffutils
     evr: 3.6-6.el8
     sourcerpm: diffutils-3.6-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/d/dracut-049-233.git20240115.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 389412
     checksum: sha256:27358d09be00920c65409cee991cac19033e33617690bf02d4d71dd896b9ec46
     name: dracut
     evr: 049-233.git20240115.el8
     sourcerpm: dracut-049-233.git20240115.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 77672
     checksum: sha256:51719dfe1f9b9bc7570beb4e47d79dec1d5307680adb2b0debd7c266604e4e8d
     name: elfutils-debuginfod-client
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.190-2.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 53904
     checksum: sha256:345728ee47941f7589211afbc839edb2101a4f2a584afd371c8dfb60c54aeeb3
     name: elfutils-default-yama-scope
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/elfutils-libelf-0.190-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 238212
     checksum: sha256:a3dd5e89bf3684b92e58205c5982921ecacbecce5f868477d0ccdd9fe779d8cf
     name: elfutils-libelf
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/elfutils-libs-0.190-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 312392
     checksum: sha256:d04814c95b050f76d7f05bc2606b08f643c3b857637f5275ccfff445df505b7e
     name: elfutils-libs
     evr: 0.190-2.el8
     sourcerpm: elfutils-0.190-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/emacs-filesystem-26.1-13.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 72256
     checksum: sha256:00cd8d7a426bfd9c80fc94077b0c87a8a7d60cd90442dc7665f6f8676452bcd7
     name: emacs-filesystem
     evr: 1:26.1-13.el8_10
     sourcerpm: emacs-26.1-13.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/e/expat-2.2.5-17.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 117960
     checksum: sha256:d01df6f542762d94bd73a87f61d19fb98a6304eb9a2eb114a872a91d3312ea34
     name: expat
     evr: 2.2.5-17.el8_10
     sourcerpm: expat-2.2.5-17.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/f/file-5.33-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 79320
     checksum: sha256:620ff70a4c50745bb242153f0a13ac4cc43b61ebbd0cd817e984efd2966ce1c9
     name: file
     evr: 5.33-26.el8
     sourcerpm: file-5.33-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/f/file-libs-5.33-26.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 557180
     checksum: sha256:3576169d440647ebfbcdda7bdd53c250a1fba14c7c1cad6e96a58e8f7e6b7ab9
     name: file-libs
     evr: 5.33-26.el8
     sourcerpm: file-5.33-26.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/f/filesystem-3.8-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1135804
     checksum: sha256:f82affbd5887242a28bc5bb3f9b3fffde0bf8e2632e958fbf13a76d450fd358a
     name: filesystem
     evr: 3.8-6.el8
     sourcerpm: filesystem-3.8-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/f/findutils-4.6.0-23.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 540248
     checksum: sha256:cb645de7da1bd495a6df969de4b0f84f10ccf8d299c26099f1cd9075ed9c32cb
     name: findutils
     evr: 1:4.6.0-23.el8_10
     sourcerpm: findutils-4.6.0-23.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gawk-4.2.1-4.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1190704
     checksum: sha256:59b3cff57ffbea4c4c011e6a81341a1203c18b91569fff019c93b756331300f8
     name: gawk
     evr: 4.2.1-4.el8
     sourcerpm: gawk-4.2.1-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gdbm-1.18-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 132820
     checksum: sha256:a8e1839ca386b258656d4a4108049857a257fbd4cf7520d698e0bfa9edd9c4c1
     name: gdbm
     evr: 1:1.18-2.el8
     sourcerpm: gdbm-1.18-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gdbm-libs-1.18-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 61820
     checksum: sha256:cfa6bd007cf38a40166de803c4aa0ccae2a6f5ffc756efa6e14a2cab228ec22b
     name: gdbm-libs
     evr: 1:1.18-2.el8
     sourcerpm: gdbm-1.18-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1119284
     checksum: sha256:6ef0f876469f7c290b53362dd983a556edd6b5c8aace9d5e94c10bf27f0179bd
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 320224
     checksum: sha256:d31afc5532d581167003977d88771f22255923bf3a1aec4dabb5ac98ec910234
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glib2-2.56.4-165.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2613332
     checksum: sha256:717d8f42ae429eb9f68320cf0a4180a6eb2ed4b4f1e7697b26bc2a0ee52c05b9
     name: glib2
     evr: 2.56.4-165.el8_10
     sourcerpm: glib2-2.56.4-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2305632
     checksum: sha256:788907956d1b917b55f8234ec6fe9da3e5b32fe7dc82d57de5ac102335abd7a9
     name: glibc
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-all-langpacks-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 26776452
     checksum: sha256:75fda392357c40a6ef4a062c0906ded57f4c9e613c61fbe87fbbb7dab9d70178
     name: glibc-all-langpacks
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-common-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1052168
     checksum: sha256:34f130bbb239441b0b177f059ce832159d968249db5242905c2c5a90559afb21
     name: glibc-common
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-devel-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 91136
     checksum: sha256:d51421bb11b703bd5070f4f3cfb7707e2df6304ebb719ada510c72424b8f0bf2
     name: glibc-devel
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1627124
     checksum: sha256:e48f8d628056669fe2c4e37e629088dd47f1004e9fe5ddec982b9741e7ebdbcd
     name: glibc-gconv-extra
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/glibc-headers-2.28-251.el8_10.16.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 505860
     checksum: sha256:7db16391024e67a9c748c72cb1b340d00fb8699429381e30ccc47d547189812e
     name: glibc-headers
     evr: 2.28-251.el8_10.16
     sourcerpm: glibc-2.28-251.el8_10.16.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gmp-6.1.2-11.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 325760
     checksum: sha256:c252d3cb19324c4e4f82c8a1dc50933be0696ebaa3b2143c036cef7fc698835d
     name: gmp
     evr: 1:6.1.2-11.el8
     sourcerpm: gmp-6.1.2-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gnutls-3.6.16-8.el8_10.3.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1043200
     checksum: sha256:a38e3151ae2430ff3b2baf87dfcf900ca290881dbfc7c61c3a651dbe3cb944b7
     name: gnutls
     evr: 3.6.16-8.el8_10.3
     sourcerpm: gnutls-3.6.16-8.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/grep-3.1-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 280356
     checksum: sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46
     name: grep
     evr: 3.1-6.el8
     sourcerpm: grep-3.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/groff-base-1.22.3-18.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1069536
     checksum: sha256:73c29baa2cd94f1ae6a1d1333818969a281b16dd4262f413ad284c5333719a4d
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/grub2-common-2.02-165.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 918848
     checksum: sha256:dba0a0d389fda562a8e32b1935e400e7f6616e72ad7d5d9b22a3488068737156
     name: grub2-common
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/grub2-tools-2.02-165.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2090600
     checksum: sha256:9349d374afdcdb59184bf66a0a41d523019b628e679b1c0984a48a79b4dca3fc
     name: grub2-tools
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/grub2-tools-minimal-2.02-165.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 221220
     checksum: sha256:a307462f138d7ca956294226190a1291c4e86c8b307dedc1e527147ab1c7c8b4
     name: grub2-tools-minimal
     evr: 1:2.02-165.el8_10
     sourcerpm: grub2-2.02-165.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/grubby-8.40-49.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 51660
     checksum: sha256:bc1f0a9e3206829b9528437ed6de4afc011d7ad392dfff720f39c4ec661f3610
     name: grubby
     evr: 8.40-49.el8
     sourcerpm: grubby-8.40-49.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gzip-1.9-13.el8_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 170828
     checksum: sha256:7f80be301cda8a6af027f15898058b1f62a0069f347a84aecb2a9c7b4c6d1ef7
     name: gzip
     evr: 1.9-13.el8_5
     sourcerpm: gzip-1.9-13.el8_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/h/hardlink-1.3-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 30016
     checksum: sha256:afb86bb3de3f8b6f8ea6be0318f95d6938749ccf91e0cabe5d95c0f197d5de1e
     name: hardlink
     evr: 1:1.3-6.el8
     sourcerpm: hardlink-1.3-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/i/info-6.5-7.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 203252
     checksum: sha256:c8bf8b80be0af687b21bdc37eed82e582f3efbe2466ce81e59f733d6029fb78b
     name: info
     evr: 6.5-7.el8
     sourcerpm: texinfo-6.5-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/j/json-c-0.13.1-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 41676
     checksum: sha256:9bd47c00f8bf9354b06ef159a5aed91ab67c4155ce02752dfe6148314dbb11e1
     name: json-c
     evr: 0.13.1-3.el8
     sourcerpm: json-c-0.13.1-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kbd-2.0.4-11.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 399268
     checksum: sha256:51439fd5ca41216da2b8f14720930edae13a34770a9332d91ec7b83c9024c06d
     name: kbd
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kbd-legacy-2.0.4-11.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 492864
     checksum: sha256:386ef39b87a49058e535015be3ec2a86847ed3c1bb9b56ae21c88e1c976b21ce
     name: kbd-legacy
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kbd-misc-2.0.4-11.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1550252
     checksum: sha256:b976dfc9467ba2a550a7e58cbac1885f5fc82afb90406cb42cb0d3d56096b016
     name: kbd-misc
     evr: 2.0.4-11.el8
     sourcerpm: kbd-2.0.4-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kernel-headers-4.18.0-553.54.1.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 12412516
     checksum: sha256:3ab9edd186d9095a70bce99e2ffe4bc827f4ffac8740aa61fe53bcbf895bf76b
     name: kernel-headers
     evr: 4.18.0-553.54.1.el8_10
     sourcerpm: kernel-4.18.0-553.54.1.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/keyutils-libs-1.5.10-9.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 34816
     checksum: sha256:240b40a71d01005c0c8f780e5589e3999e3d6aa34e2a5e4eaf6f845fd21c7b5b
     name: keyutils-libs
     evr: 1.5.10-9.el8
     sourcerpm: keyutils-1.5.10-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/keyutils-libs-devel-1.5.10-9.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 49216
     checksum: sha256:7fa4f4d0a7ae769802925335acad2875491a2d5d0e80ccb269e8c2ff03a35e6f
     name: keyutils-libs-devel
     evr: 1.5.10-9.el8
     sourcerpm: keyutils-1.5.10-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kmod-25-20.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 129356
     checksum: sha256:0d2ca4e3cdeb9929d40257e25d3be233a608bf4269a16be77a63503d78233ed2
     name: kmod
     evr: 25-20.el8
     sourcerpm: kmod-25-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kmod-libs-25-20.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 70224
     checksum: sha256:4c586c86bdf99b69ce1c250069f53fceef5b5536b8c9e10018ac25e7e7758126
     name: kmod-libs
     evr: 25-20.el8
     sourcerpm: kmod-25-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/kpartx-0.8.4-42.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 122604
     checksum: sha256:8f9e7887ed1942d744c4efe67cb2ffa093166520d3947e114c7b93f60cb1b97a
     name: kpartx
     evr: 0.8.4-42.el8_10
     sourcerpm: device-mapper-multipath-0.8.4-42.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/krb5-devel-1.18.2-31.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 576364
     checksum: sha256:909742d0197669f3498e4bfd85b70f40b7c86d312c0fb9a676f1fa43f0ebed7e
     name: krb5-devel
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/k/krb5-libs-1.18.2-31.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 865604
     checksum: sha256:061be39fa6f842b274c3a8679aab5476cab1ff42d62f590532db66cfeb97120d
     name: krb5-libs
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/less-530-3.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 168216
     checksum: sha256:e459a0babd293f436fcf14d3ca98f2bcf18b40b0345aa97d9cf9813159a1f6d6
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libacl-2.2.53-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 35644
     checksum: sha256:adfa60272a36d4b6ff9fdaf916ce16b515b0e46bc2f96e313359fad35a6fae58
     name: libacl
     evr: 2.2.53-3.el8
     sourcerpm: acl-2.2.53-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libarchive-3.3.3-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 368640
     checksum: sha256:af9fc180b9ce78e4a6fc0b7698cef52c063d5e8037e0d01c6e911c2368899cf8
     name: libarchive
     evr: 3.3.3-5.el8
     sourcerpm: libarchive-3.3.3-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libattr-2.4.48-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 27572
     checksum: sha256:2733570f8ea94551f3381538f9c8642c88532c800b384c07b4db02f6b8896c3f
     name: libattr
     evr: 2.4.48-3.el8
     sourcerpm: attr-2.4.48-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libblkid-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 226324
     checksum: sha256:4d03b6b8d7c80936ea81b1d0cfa1b65a995a931819e1e9991fdd2c52b44756da
     name: libblkid
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcap-2.48-6.el8_9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 76264
     checksum: sha256:53d1d3b3387e8fea15d204b277a6b47e07f8d53bc5e48de84db5242ae3391569
     name: libcap
     evr: 2.48-6.el8_9
     sourcerpm: libcap-2.48-6.el8_9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcap-ng-0.7.11-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 34228
     checksum: sha256:ee3b34949ba7696cc2b83a38dd57e7bd641d4b2b732018af6f222e055565bcc1
     name: libcap-ng
     evr: 0.7.11-1.el8
     sourcerpm: libcap-ng-0.7.11-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcom_err-1.45.6-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 50552
     checksum: sha256:4ec238fdfb608694b5a973f624004b8671e4e787c6addfc3c8d486a6d3bcce8f
     name: libcom_err
     evr: 1.45.6-5.el8
     sourcerpm: e2fsprogs-1.45.6-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcom_err-devel-1.45.6-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 39660
     checksum: sha256:daaa2d9c45c10f613fdf08e0ca4187466bb831046391017f6eb5b54d6b42f4ce
     name: libcom_err-devel
     evr: 1.45.6-5.el8
     sourcerpm: e2fsprogs-1.45.6-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 115260
     checksum: sha256:d0982bac60512aaf37a99078e24446337ab6210db07ed95c49baeb9a3811dd2b
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libcurl-7.61.1-34.el8_10.3.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 311596
     checksum: sha256:0642990d55ecd1cda963404cf8dcc7776302722a68bceabd610339a92660d52f
     name: libcurl
     evr: 7.61.1-34.el8_10.3
     sourcerpm: curl-7.61.1-34.el8_10.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libdb-5.3.28-42.el8_4.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 769444
     checksum: sha256:4b23f70862d887cd9ac314ee0f4b0c61aa945d1a4a254fda4dc105447714900c
     name: libdb
     evr: 5.3.28-42.el8_4
     sourcerpm: libdb-5.3.28-42.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libdb-utils-5.3.28-42.el8_4.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 153272
     checksum: sha256:6b52102af0aab3b41a5d410b7717713aef3adc48c41015a745c9c5a2ba7b814f
     name: libdb-utils
     evr: 5.3.28-42.el8_4
     sourcerpm: libdb-5.3.28-42.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 104512
     checksum: sha256:0391105afa53c9503b59591615bd7c98e2f7a4cd94ff4fd1451c4234522f3880
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libfdisk-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 260128
     checksum: sha256:e7793c66af8f2cdd7893527bc81971e50f985f27c67dc22bbf118e3e0468f1a9
     name: libfdisk
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libffi-3.1-24.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 38584
     checksum: sha256:e90e92c3364fa407cbdbb30aaf3d25b1542ee33b4269ca4953f03c74fc614d68
     name: libffi
     evr: 3.1-24.el8
     sourcerpm: libffi-3.1-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libgcc-8.5.0-26.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 84096
     checksum: sha256:64290a186b6ef8520f108f46f53690507da8b0d3c92e314db17f40e182739bc2
     name: libgcc
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libgcrypt-1.8.5-7.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 473908
     checksum: sha256:8af1caa726c0b3b398eed421511ff26222f3ddfa131b90fedaa4fe464216338c
     name: libgcrypt
     evr: 1.8.5-7.el8_6
     sourcerpm: libgcrypt-1.8.5-7.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libgomp-8.5.0-26.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 213672
     checksum: sha256:d5ae3e6eb7eb9acc9e2a1527b73a99bb4845699835d39c03a2d87f3ea2689597
     name: libgomp
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libgpg-error-1.31-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 247520
     checksum: sha256:4bef8c6105544198bc4c5fecd21202bcf7823dda888cbe3fee888ee936c46bd9
     name: libgpg-error
     evr: 1.31-1.el8
     sourcerpm: libgpg-error-1.31-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libidn2-2.2.0-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 95936
     checksum: sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec
     name: libidn2
     evr: 2.2.0-1.el8
     sourcerpm: libidn2-2.2.0-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libkadm5-1.18.2-31.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 193352
     checksum: sha256:b70e398d8a7608d6da1149a792b8c5d1ae4c75b45d08f797585241895dd93570
     name: libkadm5
     evr: 1.18.2-31.el8_10
     sourcerpm: krb5-1.18.2-31.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libkcapi-1.4.0-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 54248
     checksum: sha256:a357c4882a2e582a101302f1624dc1e63dedc102e13da0cb0d4cf523f744dc94
     name: libkcapi
     evr: 1.4.0-2.el8
     sourcerpm: libkcapi-1.4.0-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libkcapi-hmaccalc-1.4.0-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 33252
     checksum: sha256:4d714811e58208086c75608a1ebf0db27f8e46dbfa189634c76a3ab0af8935ad
     name: libkcapi-hmaccalc
     evr: 1.4.0-2.el8
     sourcerpm: libkcapi-1.4.0-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libmount-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 242716
     checksum: sha256:eff5e4d50998b9f7ecfcea058cc0bebde00b2d792ab198072ac8bb165deabb0c
     name: libmount
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libnghttp2-1.33.0-6.el8_10.1.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 80224
     checksum: sha256:7db208659d8dd140ce766390f280dbf59178846fa261acfe8f834d405cd0ce5e
     name: libnghttp2
     evr: 1.33.0-6.el8_10.1
     sourcerpm: nghttp2-1.33.0-6.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 59120
     checksum: sha256:f7e60c8a5eaf056a9c67834671561196b961fba7bc763568f1c01c3ab998bb46
     name: libnsl2
     evr: 1.2.0-2.20180605git4a062cf.el8
     sourcerpm: libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 35620
     checksum: sha256:96fadfed6a8225a89b331e7b62ed8ee74b393cea1520fa0d89f6f0dc1a458fb3
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libpsl-0.20.2-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 62896
     checksum: sha256:3384bccab530807195eb9d72547aa588bdea55567ca86d1719f32402bf1cd0c9
     name: libpsl
     evr: 0.20.2-6.el8
     sourcerpm: libpsl-0.20.2-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 109704
     checksum: sha256:ae3dfbc6ca432681b137f76bee081735d61c65db986b1238ed7837e3112d3180
     name: libpwquality
     evr: 1.4.4-6.el8
     sourcerpm: libpwquality-1.4.4-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 72932
     checksum: sha256:cf08ceb39359d00f9da0abaf15e799725288f8cd3a54d075fb37b76967776949
     name: libseccomp
     evr: 2.5.2-1.el8
     sourcerpm: libseccomp-2.5.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libselinux-2.9-10.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 170016
     checksum: sha256:41c31dde6e5e6928f66f5541586a2ed32bb088e8e5585dd6ce1d60c04e1d667f
     name: libselinux
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libselinux-devel-2.9-10.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 205304
     checksum: sha256:d5f1c4dfc6d92586a14f0969d7140b64c96114eea6eee5a3e32a6caa8b4505e1
     name: libselinux-devel
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libselinux-utils-2.9-10.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 248956
     checksum: sha256:e7e832f301b1f7e0e15ef90113ac878935d2a10b6322b378bcf74eb125efb4a7
     name: libselinux-utils
     evr: 2.9-10.el8_10
     sourcerpm: libselinux-2.9-10.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsemanage-2.9-11.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 172936
     checksum: sha256:2fbbded84101ff93c19bdaebf7b05c2950654b010c37ba5de13d7a0342bd634b
     name: libsemanage
     evr: 2.9-11.el8_10
     sourcerpm: libsemanage-2.9-11.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsepol-2.9-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 348080
     checksum: sha256:d35b0de2bd7c4cf0a2389786b7c61c8d4af176640cbd2427373faeb7c8315f6e
     name: libsepol
     evr: 2.9-3.el8
     sourcerpm: libsepol-2.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsepol-devel-2.9-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 89044
     checksum: sha256:1e1cdf795bc1ec2f86617359de5aaf05f63924679dcffb11e7e3d577ce856d47
     name: libsepol-devel
     evr: 2.9-3.el8
     sourcerpm: libsepol-2.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsigsegv-2.11-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 31012
     checksum: sha256:d0188d22323619c9069c2de6f85ebe5302c76fde5f52ebd148988e75a75110dc
     name: libsigsegv
     evr: 2.11-5.el8
     sourcerpm: libsigsegv-2.11-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsmartcols-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 184132
     checksum: sha256:69598308df2327d9bca762c9d52041fa9837d51984f8bbc13e16016d49af8273
     name: libsmartcols
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libssh-0.9.6-14.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 225336
     checksum: sha256:3acf41aee9f1bf30fbf498becb44a695209e4fe3172354c1ee4796cdf6dd05b4
     name: libssh
     evr: 0.9.6-14.el8
     sourcerpm: libssh-0.9.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libssh-config-0.9.6-14.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 21548
     checksum: sha256:e8281fb82a512c0bbfdd4bbd0f7f9657fce2ad547189fb93d0a0bf814173a2a4
     name: libssh-config
     evr: 0.9.6-14.el8
     sourcerpm: libssh-0.9.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libstdc++-8.5.0-26.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 484720
     checksum: sha256:5bb9487cc69fa20dfd8ba6a27976ed618cf53ef23a8b4d6709e3de1e3ed73184
     name: libstdc++
     evr: 8.5.0-26.el8_10
     sourcerpm: gcc-8.5.0-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libtasn1-4.13-5.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 78540
     checksum: sha256:931affa15d7a999db69c5f04f746340ee6e45c78569872b22828dd6e0f0e36d0
     name: libtasn1
     evr: 4.13-5.el8_10
     sourcerpm: libtasn1-4.13-5.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libtirpc-1.1.4-12.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 116808
     checksum: sha256:d35b01a79f17bcaca9a774fa78136acadabf6f627db43b7dca43a83a63afffa4
     name: libtirpc
     evr: 1.1.4-12.el8_10
     sourcerpm: libtirpc-1.1.4-12.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libunistring-0.9.9-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 432360
     checksum: sha256:07d885ed980e09242fa1b6b4faaa5aaf3ea1f24415ac86a6a1f2f08ab5797784
     name: libunistring
     evr: 0.9.9-3.el8
     sourcerpm: libunistring-0.9.9-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libutempter-1.1.6-14.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 32564
     checksum: sha256:ebc4d394a251feba7e1025d7f8ba61e619c2a6fc14229482bf28096e49cef520
     name: libutempter
     evr: 1.1.6-14.el8
     sourcerpm: libutempter-1.1.6-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libuuid-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 101656
     checksum: sha256:5f24ded4d1436da0fef69b6c9288768ce41e1d2caf4849c49426e06d5212f5af
     name: libuuid
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libverto-0.3.2-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 24636
     checksum: sha256:984b30f3b4e34fb2b2659331df9d13c27301fd7ae6b6ea86860a5a1ac9d62597
     name: libverto
     evr: 0.3.2-2.el8
     sourcerpm: libverto-0.3.2-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libverto-devel-0.3.2-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 18488
     checksum: sha256:b1c155902a1250ae5beebe1c37e77ff8d4ab2e414324aba15373c6e42570acc0
     name: libverto-devel
     evr: 0.3.2-2.el8
     sourcerpm: libverto-0.3.2-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libxcrypt-4.1.1-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 74508
     checksum: sha256:ef9144f8c9d3f8c1a28146055370065e7b546f1163caabd08bc7d54667702982
     name: libxcrypt
     evr: 4.1.1-6.el8
     sourcerpm: libxcrypt-4.1.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libxcrypt-devel-4.1.1-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 25844
     checksum: sha256:f747e081cde1b64bd018e858928aa45dd3b160e6493f8b9c35488a19b6783a84
     name: libxcrypt-devel
     evr: 4.1.1-6.el8
     sourcerpm: libxcrypt-4.1.1-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libxml2-2.9.7-19.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 713464
     checksum: sha256:c2eefe2e9fa41729d7841dc2959eb0da4504fb42288db3232ad41917319d5ebd
     name: libxml2
     evr: 2.9.7-19.el8_10
     sourcerpm: libxml2-2.9.7-19.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libzstd-1.4.4-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 272364
     checksum: sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25
     name: libzstd
     evr: 1.4.4-1.el8
     sourcerpm: zstd-1.4.4-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/lua-libs-5.3.4-12.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 120792
     checksum: sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0
     name: lua-libs
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/lz4-libs-1.8.3-3.el8_4.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 67392
     checksum: sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc
     name: lz4-libs
     evr: 1.8.3-3.el8_4
     sourcerpm: lz4-1.8.3-3.el8_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/m/make-4.2.1-11.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 509756
     checksum: sha256:0e4e8e667208c6f9b01c7289269e8b0274984359111173a751b67b7c7d47ffec
     name: make
     evr: 1:4.2.1-11.el8
     sourcerpm: make-4.2.1-11.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/m/memstrack-0.2.5-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 52828
     checksum: sha256:e405ac7abbe7722f194c47f0589da187ec28c01e6efbb846b775864b0f65c6b2
     name: memstrack
     evr: 0.2.5-2.el8
     sourcerpm: memstrack-0.2.5-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/m/mpfr-3.1.6-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 226672
     checksum: sha256:28ccf9ff472c824f6c5a3c2a0c076bfa221b8e48368e43de9b3c2e83d67e8b5d
     name: mpfr
     evr: 3.1.6-1.el8
     sourcerpm: mpfr-3.1.6-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 396400
     checksum: sha256:998836898721566d3ff94e6d8babada71cc3635169c0763f4b53afabc5446fa1
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/n/ncurses-base-6.1-10.20180224.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 83276
     checksum: sha256:207f5578dd44a73761178f8b01030151e44d3d046c1578446d558c5a0a2bf34a
     name: ncurses-base
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/n/ncurses-libs-6.1-10.20180224.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 341660
     checksum: sha256:19bd810dfea7846a38a3b61ff47eaf758d2fd9d327e94eb0c7562de4c59414d5
     name: ncurses-libs
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/n/nettle-3.4.1-7.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 308276
     checksum: sha256:51eb082082e78afa70dd64591219c026d11cf7a6adf3771a36624c80be34dc3e
     name: nettle
     evr: 3.4.1-7.el8
     sourcerpm: nettle-3.4.1-7.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openldap-2.4.46-21.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 362080
     checksum: sha256:59d89d8613dd2cd2391e919f5207a04df017479bb7691479c95dc84d21e0cda4
     name: openldap
     evr: 2.4.46-21.el8_10
     sourcerpm: openldap-2.4.46-21.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssh-8.0p1-25.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 538364
     checksum: sha256:5a907994ecbd9800a83ffcd9be24fdfe5a8da79784eb14b5a63ac4b30f5da83b
     name: openssh
     evr: 8.0p1-25.el8_10
     sourcerpm: openssh-8.0p1-25.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssh-clients-8.0p1-25.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 661916
     checksum: sha256:ddce4aeedd5f387aeaa4f0f63e79b2288cc456859af502500d78c6270d1d84b5
     name: openssh-clients
     evr: 8.0p1-25.el8_10
     sourcerpm: openssh-8.0p1-25.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 728108
     checksum: sha256:a8e4ff3346cfa24713f54d2a9e2b53ad7f3c9d84a6c639ba2150b7cb09550af0
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssl-devel-1.1.1k-14.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2439792
     checksum: sha256:40f49e4e0fa180d59d954306534bf7176506d5b68f849ce922ce89fedaffb656
     name: openssl-devel
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssl-libs-1.1.1k-14.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1542788
     checksum: sha256:5c87e7ec6269dbe1ec4922adc4016b5117fd5ecf8177015e76f471699f0de5f1
     name: openssl-libs
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/openssl-pkcs11-0.4.10-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 67740
     checksum: sha256:035d3b090309c940d4c56179a069febacbe65b8119950ce59bbdce88ce85b9d7
     name: openssl-pkcs11
     evr: 0.4.10-3.el8
     sourcerpm: openssl-pkcs11-0.4.10-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/o/os-prober-1.74-9.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 52600
     checksum: sha256:2711faf7ba62de2e1b8254f1787be9be2e1354cc43a64af2744f32f16877ebfd
     name: os-prober
     evr: 1.74-9.el8
     sourcerpm: os-prober-1.74-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/p11-kit-0.23.22-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 334852
     checksum: sha256:25cea1589f41afdf0397e8b48a8b333976ec545ecafdacdb701481726279193f
     name: p11-kit
     evr: 0.23.22-2.el8
     sourcerpm: p11-kit-0.23.22-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/p11-kit-trust-0.23.22-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 141216
     checksum: sha256:68289d90ace259e65df400cada3ec8d1fded98a2a33b92bbca4f1029b300c748
     name: p11-kit-trust
     evr: 0.23.22-2.el8
     sourcerpm: p11-kit-0.23.22-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pam-1.3.1-36.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 765548
     checksum: sha256:92bb7478c5945f4c83f748197ffb3ead918ba55e2d08448be6bafdbafbc2c821
     name: pam
     evr: 1.3.1-36.el8_10
     sourcerpm: pam-1.3.1-36.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pcre-8.42-6.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 215668
     checksum: sha256:d1dbdff1f5e543bc5dcd8c957b07947cebd9ae4c3ba6d0cdf52a2a8c014c2fd5
     name: pcre
     evr: 8.42-6.el8
     sourcerpm: pcre-8.42-6.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pcre2-10.32-3.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 252604
     checksum: sha256:c504e02ff8af5607b7b23bcdceee78f728ab16a9adc053bd774739d520d95ecb
     name: pcre2
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pcre2-devel-10.32-3.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 619372
     checksum: sha256:48df73d35b1c572e8f8cf9d7318a299ff007776bb5e1677447386b4dcb0e802e
     name: pcre2-devel
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pcre2-utf16-10.32-3.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 234504
     checksum: sha256:91df207ab87117b29695ad94eccaa1fab29dad76e6ea459647b16ece6d4aad08
     name: pcre2-utf16
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pcre2-utf32-10.32-3.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 225776
     checksum: sha256:81ca26b980903a64de28fc8ef49383e60a907aa8f573fac8788279b479480de7
     name: pcre2-utf32
     evr: 10.32-3.el8_6
     sourcerpm: pcre2-10.32-3.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 59400
     checksum: sha256:07820bf56fb684093cebe7f0be962785dd918e71082201eed45eae2cefc30669
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Digest-MD5-2.55-396.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 37880
     checksum: sha256:83ffd804a5c0ac401ea30620a563a57bbfd2eb1f16cbc6813b7ea22303ac9f53
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Encode-2.97-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1545496
     checksum: sha256:5662a18ee7856572448295b688c12c2378a3f9fb830d1703da4c8491416b2586
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Errno-1.28-422.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 78368
     checksum: sha256:b077b72ea9761dfd6a6d53a88ad1c2ef81c91698e6730fe4da802c93515140e5
     name: perl-Errno
     evr: 1.28-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-IO-1.38-422.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 145752
     checksum: sha256:61c1eb74dcdbff918676bdf1ee3b7dec14f6cf3201c88b96e62e2e92cb4b3410
     name: perl-IO
     evr: 1.38-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 31396
     checksum: sha256:78c75125187f1f8d66a6106ea7b07e8cf2b57c18bf85f6dd888842464b128a5c
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 92196
     checksum: sha256:0e5d51dc3249aa800150bac70d394ad650dc509bebbec35446494f86cd92aecc
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 69428
     checksum: sha256:fbc4b08c066f448d213ba5acbcf20a8931c419d2238bc0fe5dd39f71bdf9b30d
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Socket-2.027-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 60224
     checksum: sha256:cec7c0d124dc281ef4befe001bceabbeba83c5bf05c9a4430102b490cc8bf8e8
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Storable-3.11-3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 100672
     checksum: sha256:ceb9382fbfb2bda85764ea055ffdad26a202c5d8744d867472eb75020060a5aa
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 83844
     checksum: sha256:e2ad63f39d3e929d08f4938fb325a861bfa19715a3701dfceb06391d18ef3c42
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-interpreter-5.26.3-422.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 6622284
     checksum: sha256:1d041e2c086d3ca598a780715a15e6dd34583f5e03add5c55e1da677e9b1746c
     name: perl-interpreter
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-libs-5.26.3-422.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1633888
     checksum: sha256:1fd03ff6a45935df8f1c93d8dd4919d46aba52ebb0d3b2dbab1bde85607c72a9
     name: perl-libs
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-macros-5.26.3-422.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 74284
     checksum: sha256:9e8e213d365f3f4d2eb49da38757fc0798c5263af8d441b7df0bab1762f98f7b
     name: perl-macros
     evr: 4:5.26.3-422.el8
     sourcerpm: perl-5.26.3-422.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-threads-2.21-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 62692
     checksum: sha256:0d3f8e14265aa162bfcec4aff8064fa26188f1e51e897f20760bab906a9f9e5e
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 48800
     checksum: sha256:78af5e69d8a6b9dd041ec748e7401ed6f0ce80f2003f43a7723816d0b2aa4c69
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pigz-2.4-4.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 81276
     checksum: sha256:bd9271820c03337924ca655f164e34a158a4d3b88fb03c18eb822cb6a66a083f
     name: pigz
     evr: 2.4-4.el8
     sourcerpm: pigz-2.4-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 38956
     checksum: sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 15628
     checksum: sha256:1c4a8674eafc31d36030f3fd0c081326d4301570d4e35b59d6f6ef1e163f655b
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/platform-python-3.6.8-69.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 90592
     checksum: sha256:43e2eac6440b86c1ec9eec337abed72a2878adc0ec11aecc506de59963c47fb9
     name: platform-python
     evr: 3.6.8-69.el8_10
     sourcerpm: python3-3.6.8-69.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/platform-python-pip-9.0.3-24.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1633024
     checksum: sha256:a9104ca3388b74f665c2648cde81043cc7748bf1ca5a7f2a4148b86013206fc8
     name: platform-python-pip
     evr: 9.0.3-24.el8
     sourcerpm: python-pip-9.0.3-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/platform-python-setuptools-39.2.0-8.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 647476
     checksum: sha256:8f330a8602613473b6e4c0bc57cb3012932a9a9399ea7a3fa65175453a6580ab
     name: platform-python-setuptools
     evr: 39.2.0-8.el8_10
     sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/policycoreutils-2.9-26.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 385980
     checksum: sha256:9cea1d9d40ae47e719f74297b2f2f03a2a270bf18463db5690c089d1e7c72e2b
     name: policycoreutils
     evr: 2.9-26.el8_10
     sourcerpm: policycoreutils-2.9-26.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/popt-1.18-1.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 62856
     checksum: sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275
     name: popt
     evr: 1.18-1.el8
     sourcerpm: popt-1.18-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/procps-ng-3.3.15-14.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 337976
     checksum: sha256:04ecbee4e131df365e8beadc54b4610ccaecf445d9541ebb5e40a2394a6bb023
     name: procps-ng
     evr: 3.3.15-14.el8
     sourcerpm: procps-ng-3.3.15-14.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 57592
     checksum: sha256:f8c191d8b952621d10a1055be960bbe07be66f557c5a9d007f8908abcde1b9af
     name: publicsuffix-list-dafsa
     evr: 20180723-1.el8
     sourcerpm: publicsuffix-list-20180723-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/python3-libs-3.6.8-69.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 8251108
     checksum: sha256:6dcf5dcbb3000fe90877bafbb4e8bb9f9a170b262c12f7ae8033e649227cf1b0
     name: python3-libs
     evr: 3.6.8-69.el8_10
     sourcerpm: python3-3.6.8-69.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/python3-pip-wheel-9.0.3-24.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 886996
     checksum: sha256:9bf511b12174637c1163f224deb28a0ea7f8f4565231e3a0e8eb64f37ce27d08
     name: python3-pip-wheel
     evr: 9.0.3-24.el8
     sourcerpm: python-pip-9.0.3-24.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-39.2.0-8.el8_10.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 296040
     checksum: sha256:833dcb68b1eea48bfb8853886236753647743258fd74cc538ffa72408aab9213
     name: python3-setuptools-wheel
     evr: 39.2.0-8.el8_10
     sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/readline-7.0-10.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 204216
     checksum: sha256:ef221ca565f17ed425997e97fdeb5fc27261910659fa61372b18d93e1a5613e9
     name: readline
     evr: 7.0-10.el8
     sourcerpm: readline-7.0-10.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/redhat-release-8.10-0.3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 46580
     checksum: sha256:e0e166b34568c303eca2ff0b4ba24dc5d945b8415a5c7b1c0e8b72dd2c70434b
     name: redhat-release
     evr: 8.10-0.3.el8
     sourcerpm: redhat-release-8.10-0.3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/redhat-release-eula-8.10-0.3.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 21324
     checksum: sha256:ec51e402dbc0961a77b166ed1c5bfe3628f2dd4a44c0622b3a56b48019248b6d
     name: redhat-release-eula
     evr: 8.10-0.3.el8
     sourcerpm: redhat-release-8.10-0.3.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/rpm-4.14.3-32.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 557660
     checksum: sha256:2a363cf9c0f09458763de829a16805e7f3809d0b80c83717da724c435d5fbbd5
     name: rpm
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/rpm-libs-4.14.3-32.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 356764
     checksum: sha256:b5637a8f70da9e229a51e0e4552e6127704220661ee1181ab55465c6b265839f
     name: rpm-libs
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.14.3-32.el8_10.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 80456
     checksum: sha256:4f7425bec662d9d6d7e9b75892e218bed1d5b65ebd1de44cbc6766d698b4b303
     name: rpm-plugin-selinux
     evr: 4.14.3-32.el8_10
     sourcerpm: rpm-4.14.3-32.el8_10.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/sed-4.5-5.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 305372
     checksum: sha256:a9ece4c02cb38584287a36c11f506f0c8a8f278724742531b9e2b0ace6585bbe
     name: sed
     evr: 4.5-5.el8
     sourcerpm: sed-4.5-5.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/selinux-policy-3.14.3-139.el8_10.1.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 685712
     checksum: sha256:9fa9ef9f606ef3a0d62bdf0fe98d9847fe511333f23bd791f1a6ad22ff62b2a1
     name: selinux-policy
     evr: 3.14.3-139.el8_10.1
     sourcerpm: selinux-policy-3.14.3-139.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/selinux-policy-targeted-3.14.3-139.el8_10.1.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 16155856
     checksum: sha256:7289ba82da048c506f2e22053bda0229d4f8d85f7657ba20cdc0043cc8d8f372
     name: selinux-policy-targeted
     evr: 3.14.3-139.el8_10.1
     sourcerpm: selinux-policy-3.14.3-139.el8_10.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/setup-2.12.2-9.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 185300
     checksum: sha256:da010e1bf1c658361a7b2a38c86bcfc82470c994b2793f5f80509d73cb468fd6
     name: setup
     evr: 2.12.2-9.el8
     sourcerpm: setup-2.12.2-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/shadow-utils-4.6-22.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1292332
     checksum: sha256:ea73ee201451bbca0d6d14ca434c93800f01c8fb1b9daef727a5af1a27356d07
     name: shadow-utils
     evr: 2:4.6-22.el8
     sourcerpm: shadow-utils-4.6-22.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/shared-mime-info-1.9-4.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 336852
     checksum: sha256:8fef82a0871742672010e7b990d7c67a6bdfc47eb58eef85f963b8abffd9c545
     name: shared-mime-info
     evr: 1.9-4.el8
     sourcerpm: shared-mime-info-1.9-4.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/sqlite-libs-3.26.0-19.el8_9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 595084
     checksum: sha256:4dc6160b4cdd96fc0205f18cc9f0dd0e8e276b8a05c511319469e1a7b44b2425
     name: sqlite-libs
     evr: 3.26.0-19.el8_9
     sourcerpm: sqlite-3.26.0-19.el8_9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/systemd-239-82.el8_10.5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 3825744
     checksum: sha256:116ad89ce7a4368e19e1a22f07fb5e6d1c5227fc8eee708f2df697b68c77d6e5
     name: systemd
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/systemd-libs-239-82.el8_10.5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1196408
     checksum: sha256:064b35388b6c188002193500c53fbee2e7d4bb754810d62cdf37883d4361df94
     name: systemd-libs
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/systemd-pam-239-82.el8_10.5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 526292
     checksum: sha256:35fe48ea4c2fc1b364b901b42a432b9fd1fb4edece973aca8a6e4773b04cf0a3
     name: systemd-pam
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/systemd-udev-239-82.el8_10.5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 1663872
     checksum: sha256:a55541d2ba40e1a2ae356e6135f71dbf95d60e9c1545a7d51074709fbb466c0e
     name: systemd-udev
     evr: 239-82.el8_10.5
     sourcerpm: systemd-239-82.el8_10.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/t/tar-1.30-9.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 858812
     checksum: sha256:6b0dc7341d743c89fa038292a7e04761ebb6cc98208ebc26dee9f01e2c1a9529
     name: tar
     evr: 2:1.30-9.el8
     sourcerpm: tar-1.30-9.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/t/trousers-0.3.15-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 156324
     checksum: sha256:034e984597ebcc557fa990b949b86c0218b472462e0301726d6e69fd4e240c79
     name: trousers
     evr: 0.3.15-2.el8
     sourcerpm: trousers-0.3.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/t/trousers-lib-0.3.15-2.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 171688
     checksum: sha256:e105832fbb20b553e4b8a503352312dfa73eef94c11f82a22b713e334c2e6a1a
     name: trousers-lib
     evr: 0.3.15-2.el8
     sourcerpm: trousers-0.3.15-2.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/t/tzdata-2025b-1.el8.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 488428
     checksum: sha256:338539f7f0cd2770694153af81e2e65121b050a1bb555ad66a6fb6f562732602
     name: tzdata
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/u/util-linux-2.32.1-46.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 2597616
     checksum: sha256:1accef88d06655139903a7b4aa6a01cab62b3c899a93d297cb7ac92a476abed6
     name: util-linux
     evr: 2.32.1-46.el8
     sourcerpm: util-linux-2.32.1-46.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/w/which-2.21-20.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 50960
     checksum: sha256:0778474c5d14d644f337f4ca2d2896598d27a71c097fa53e373b7c07e6b5384d
     name: which
     evr: 2.21-20.el8
     sourcerpm: which-2.21-20.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/x/xz-5.2.4-4.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 156884
     checksum: sha256:fa4ceb20dbf23e9408a6446fefc4b709bc85e0bc563ca423569bbe08ecee2c5e
     name: xz
     evr: 5.2.4-4.el8_6
     sourcerpm: xz-5.2.4-4.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/x/xz-libs-5.2.4-4.el8_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 96140
     checksum: sha256:384b65e2c4f698a7aab049df1c2dc86a03a26742852a2d69d4000e028edbcf19
     name: xz-libs
     evr: 5.2.4-4.el8_6
     sourcerpm: xz-5.2.4-4.el8_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/z/zlib-1.2.11-25.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 105848
     checksum: sha256:7b443e7b008f38c216dd7b36c0d6ce64ececd8b884a91706c7f878140ec5f332
     name: zlib
     evr: 1.2.11-25.el8
     sourcerpm: zlib-1.2.11-25.el8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/z/zlib-devel-1.2.11-25.el8.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-8-for-x86_64-baseos-rpms
     size: 59988
     checksum: sha256:c74f32f85c67944dd993ae858fb29771886ba4b84c45cfa55b4c4e46a1228a60
     name: zlib-devel
@@ -4582,1027 +4582,1027 @@ arches:
     sourcerpm: zlib-1.2.11-25.el8.src.rpm
   source:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/c/container-selinux-2.229.0-2.module+el8.10.0+22931+799fd806.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 68445
     checksum: sha256:97e408e247ad39d0c2365a5c777ae725e4e515e1d9e386ea6f500899b3bbc026
     name: container-selinux
     evr: 2:2.229.0-2.module+el8.10.0+22931+799fd806
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/d/delve-1.24.1-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 9617211
     checksum: sha256:f2cc1f7ce0ff833db04bb5b97d495bebb38525cf034f0ac7d5abbffd3468bd04
     name: delve
     evr: 1.24.1-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/g/git-2.43.5-2.el8_10.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 7492234
     checksum: sha256:84abeac488878a765f05d3161f22684c2fb0bcdf8abcd9cf7a5378da936b7ea0
     name: git
     evr: 2.43.5-2.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/g/go-toolset-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 18120
     checksum: sha256:f7db9f33a706444f6b51f46ed0d250cf6bf905ca117fe827b38a48cfd157d1a4
     name: go-toolset
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/g/golang-1.23.6-1.module+el8.10.0+22945+b2c96a17.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 28202728
     checksum: sha256:da4c25b57a92457c1dd29297864bcabad04c383fddc5360299da6c5352cee852
     name: golang
     evr: 1.23.6-1.module+el8.10.0+22945+b2c96a17
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/i/isl-0.16.1-6.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 2707870
     checksum: sha256:0b30f2b8493eed1143ef416bfe9224db269e282a5e7a43cad6a2d13cb6311beb
     name: isl
     evr: 0.16.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/l/libmpc-1.1.0-9.1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 1271618
     checksum: sha256:abc6027ff19edf00eb50dd86e37facba5bd9898da9ccd8aa9cc1f934fbe68e58
     name: libmpc
     evr: 1.1.0-9.1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/l/libxkbcommon-0.9.1-1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 390739
     checksum: sha256:ca72f33bbbdd245bf1d2385e5f934d36b0ebdc9854b242fce7be0bb56bfa8255
     name: libxkbcommon
     evr: 0.9.1-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/p/perl-Error-0.17025-2.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 50040
     checksum: sha256:37a96e1b17c437d30b66159af7ff16681d2de05fe063db57e61261caf7f00d2b
     name: perl-Error
     evr: 1:0.17025-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 342192
     checksum: sha256:d5ad0d4f7fb6c7bdf176cbf04f9a8b2763fe58329155c4c52a6e13e4cc0dc4e8
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 169249
     checksum: sha256:ae5fce417f096e72b57e410058740582f34253a2544019da19324aea3b71f598
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 494211
     checksum: sha256:29f51f6c0a352cc9dbbc1f7b5a04de7a8a50611fe7c1ec32c7ebce4a1b456689
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.37-7.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 101242
     checksum: sha256:168b753e84508c60384408710a0c305b4e8ead3ff1163abae23e48d16e14d77c
     name: perl-TermReadKey
     evr: 2.37-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/source/SRPMS/Packages/x/xkeyboard-config-2.28-1.el8.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-8-for-x86_64-appstream-source-rpms
     size: 1699339
     checksum: sha256:e17ddb6b3789908ccb750893fda134141e08ae0fd0618cc6b059d46257ba200f
     name: xkeyboard-config
     evr: 2.28-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/a/acl-2.2.53-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 549872
     checksum: sha256:3f8720a9425f7575d0314034538412a54e6cc482cc642bcdccb95679e362ef93
     name: acl
     evr: 2.2.53-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/a/attr-2.4.48-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 491219
     checksum: sha256:07bef8d477176042b940e5732eba1600871aacc1a0dbe679952d62265b5e6dbc
     name: attr
     evr: 2.4.48-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1248664
     checksum: sha256:c1facd2ecc520c758bbe2b049207629ad08914798f63c92beef4790086ad2f29
     name: audit
     evr: 3.1.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/b/basesystem-11-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 11934
     checksum: sha256:95fb2c11bd59c51fcb0c0239e3e2c307d7d8d40c24b2960792bbc8af8c14f95c
     name: basesystem
     evr: 11-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/b/bash-4.4.20-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 9478334
     checksum: sha256:670d393f3d288bc61519be0d2c5378addc1cd4a752b738ce2424b69618f3965c
     name: bash
     evr: 4.4.20-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.30-125.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 21080005
     checksum: sha256:3dfe179ebe80b9640e735710b9f01476905687dc10e5a3516438b24d65e66ff3
     name: binutils
     evr: 2.30-125.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/b/brotli-1.0.6-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 23835509
     checksum: sha256:d269796bbd35c8ef524e4070d347f8b74cf1f10caa1bd4b19c30d69f24761f2a
     name: brotli
     evr: 1.0.6-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/b/bzip2-1.0.6-28.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 807250
     checksum: sha256:9c1d697f675f5889c57e7f983afa4b3e3f6e2334887ded9d7c10c5a205d1b06a
     name: bzip2
     evr: 1.0.6-28.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 715540
     checksum: sha256:a066b501d49019ad53d7a8bd7badd1b073f317e406561f0cfad59b7bdfaba0a6
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-80.0.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/chkconfig-1.19.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 221618
     checksum: sha256:7cf522c35fa5a5906c8c793ece9e599e80aba6c37d3f57afbf436c9abb8629c6
     name: chkconfig
     evr: 1.19.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/coreutils-8.30-15.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5550193
     checksum: sha256:8e6d8f3d8929cfd896c09a6d7ebfdd0d78fd028169042f7df9e35803189e4eee
     name: coreutils
     evr: 8.30-15.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/cpio-2.12-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1312438
     checksum: sha256:23581dd4cd8175797ee2c6c4ae48fd679e8d3a5375ebc41df056a497334443db
     name: cpio
     evr: 2.12-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-15.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 6423670
     checksum: sha256:835902fc3455d9e3b132ed1f8f63eefc4adf1c7d505771604ff89cb2f0116f0c
     name: cracklib
     evr: 2.9.6-15.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/crypto-policies-20230731-1.git3177e06.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 97044
     checksum: sha256:48c7b69ead3bf12dfb7c1d20807f63057429636325aae5bd6f1ae166b38fcf2e
     name: crypto-policies
     evr: 20230731-1.git3177e06.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.3.7-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 11381421
     checksum: sha256:21bb087ab9a3d64c89295a1bd45b5e5b6189832a972d4b3ddccb2ff5437ac2ed
     name: cryptsetup
     evr: 2.3.7-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/curl-7.61.1-34.el8_10.3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2629169
     checksum: sha256:da74fbd455075a1e124a5251e17946c0a2c8b8bd023e349d0c52b3cee8e3d37c
     name: curl
     evr: 7.61.1-34.el8_10.3
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-6.el8_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 4032772
     checksum: sha256:72d534b444990dbb647ead881f77e841ef9416109054cf74b7a5d12f912eef9a
     name: cyrus-sasl
     evr: 2.1.27-6.el8_5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/d/dbus-1.12.8-26.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2149642
     checksum: sha256:4934fea4bcebaf82dacd6d8258b35233f25e66cfd45d68f6b6e48d2ff3632395
     name: dbus
     evr: 1:1.12.8-26.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/d/device-mapper-multipath-0.8.4-42.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 770004
     checksum: sha256:1d1b1002cc499a2ab55a5288260f666fd0f6e077166708dd47d8f02efcfd3bd2
     name: device-mapper-multipath
     evr: 0.8.4-42.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/d/diffutils-3.6-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1427759
     checksum: sha256:1308e782ad4f9b17a5cbbac9734be496948db857de7458b3388645bf1786892d
     name: diffutils
     evr: 3.6-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/d/dracut-049-233.git20240115.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 582719
     checksum: sha256:21cebc2005d7aa0b6cd45f1a5455ac85f75399b8d3f2a38de3f47585f2200acd
     name: dracut
     evr: 049-233.git20240115.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.45.6-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5675423
     checksum: sha256:1c0771ea038777ecf84ba31cba0c3d221d39e351c1a6e7967857977c1949c792
     name: e2fsprogs
     evr: 1.45.6-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.190-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 9288737
     checksum: sha256:54fe49a6fd4f87d6fd594b62c465105fc3efab05a1ffcc216f053c277ab619bf
     name: elfutils
     evr: 0.190-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/e/emacs-26.1-13.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 44386554
     checksum: sha256:302fc2e7df4c6912cd349b739fde793bcc9f785b260d1ac406f37a5012b47512
     name: emacs
     evr: 1:26.1-13.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/e/expat-2.2.5-17.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 8345318
     checksum: sha256:41de03fcbf3a8f7fa42e7017058ae0186e98a0e448ce01772de7af0a856a749d
     name: expat
     evr: 2.2.5-17.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/f/file-5.33-26.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 899551
     checksum: sha256:1bdcfa5032e3ef5ff5f9f72233b6c9c67c0c7ff994a04df131d3b64b213b99cb
     name: file
     evr: 5.33-26.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/f/filesystem-3.8-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 37286
     checksum: sha256:113b7c5e28cc1d44e21c564c17d8c592a3f8a20b4c268cdaad6a407dee4d1540
     name: filesystem
     evr: 3.8-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/f/findutils-4.6.0-23.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 3831527
     checksum: sha256:28510e1bb0c939d1b945f889611cf572e03ee18faaa5bff6f0ad203fd696fb29
     name: findutils
     evr: 1:4.6.0-23.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gawk-4.2.1-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 3036497
     checksum: sha256:fac4ea2cb712ff3f0dd723d6eec358e051040592492b5cf6bd66354b8a09f143
     name: gawk
     evr: 4.2.1-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gcc-8.5.0-26.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 65714976
     checksum: sha256:12ebb9cdefb5f8c68bbce3eb469440d26f0d64de958751f4916328ed02522ed2
     name: gcc
     evr: 8.5.0-26.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gdbm-1.18-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 966590
     checksum: sha256:e91abeb46538fc264936c0eed825c28eab9eef47288c9eb1d2d4d078bccad5d1
     name: gdbm
     evr: 1:1.18-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gettext-0.19.8.1-17.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 7264423
     checksum: sha256:114be9b072a7726f2ac557fda6b8a86254ae3b7ed984ed14cfa7733bea9005d4
     name: gettext
     evr: 0.19.8.1-17.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/glib2-2.56.4-165.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 7127086
     checksum: sha256:0d418524f04a24e2357b26d4107424780acca901a1575a7a5cbf178b2aa1458c
     name: glib2
     evr: 2.56.4-165.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.28-251.el8_10.16.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 18487094
     checksum: sha256:f988b183ac97142187843e95dab32f9d7bc8bce3723c80a535a3dfdabba08a44
     name: glibc
     evr: 2.28-251.el8_10.16
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gmp-6.1.2-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2430007
     checksum: sha256:0be11faec5810961b3b5b2f0e8a54c4628b62bb2bec4e282f47682c4be0cef64
     name: gmp
     evr: 1:6.1.2-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gnutls-3.6.16-8.el8_10.3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5774773
     checksum: sha256:e3dc1e166a626f8ff303c9d9a260d4a1ac68cd2a62d28bfec51d6b1aa3670053
     name: gnutls
     evr: 3.6.16-8.el8_10.3
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/grep-3.1-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1412532
     checksum: sha256:c5d8342de1536365d5ccb340a4a381b40529eb98a6866981df956e4adc2727ac
     name: grep
     evr: 3.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.3-18.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 4272813
     checksum: sha256:3d70ed8c7784143119218a32b413fa210c04f380018c6c801a33f7e33885ed19
     name: groff
     evr: 1.22.3-18.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/grub2-2.02-165.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 8327584
     checksum: sha256:01c652d9a48600b8a77f44c9d93878db5f5fffd3b4f0f9988fae892020feeb56
     name: grub2
     evr: 1:2.02-165.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/grubby-8.40-49.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 233771
     checksum: sha256:cf243444b0a597051b63da2c3fc86a89d6e187549f0765edd2129ba8ab48f48c
     name: grubby
     evr: 8.40-49.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.9-13.el8_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 822025
     checksum: sha256:cca21983255b0d999938c7a42a43d6402ab4bce1dbd058a16d6c4a2e6b95d763
     name: gzip
     evr: 1.9-13.el8_5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/h/hardlink-1.3-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 27360
     checksum: sha256:f6f9b604b76e2871dabd14205cb7ed0c5abcdb0e597c1da4cd1c310f7567c7d3
     name: hardlink
     evr: 1:1.3-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/j/json-c-0.13.1-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 647075
     checksum: sha256:f68a400c6a103bf4c37e1c43c2716386beb087519b21204b8b2dd1f85392d528
     name: json-c
     evr: 0.13.1-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/k/kbd-2.0.4-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1073844
     checksum: sha256:9ccad26b460609bc75dfe8795f72dbdcc9fdd08529de1398a7d2a205d6d20ad3
     name: kbd
     evr: 2.0.4-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/k/kernel-4.18.0-553.54.1.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 138634600
     checksum: sha256:d0cfc85108f3424439bdec96ba6ee20360f0b5c43efc76dad9c0b0bec7d181db
     name: kernel
     evr: 4.18.0-553.54.1.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.5.10-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 103686
     checksum: sha256:8b3c331a0500880d8cd6e5ccdcb7e6600e5be5fbfe4a7a203b4acc0dbe09a562
     name: keyutils
     evr: 1.5.10-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/k/kmod-25-20.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 584947
     checksum: sha256:3df9490dc2b5146a1e0953d254540d64b7e0c304c52ebd64baf2eeb78eae70bd
     name: kmod
     evr: 25-20.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/k/krb5-1.18.2-31.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 10383931
     checksum: sha256:1c1468efcb7c58f7e40727e45deb6f7d30b8ddb3acaa192a15807af8f1fdfc22
     name: krb5
     evr: 1.18.2-31.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/less-530-3.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 381600
     checksum: sha256:3a3fb5787be53264b5619eda709d8dc7a0f2eb8bfd658569d6543baff36e7366
     name: less
     evr: 530-3.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libarchive-3.3.3-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 6570219
     checksum: sha256:97e61fdb02920262ab2c2506465dca8492b33050561d3d981ed1065083166c3e
     name: libarchive
     evr: 3.3.3-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libcap-2.48-6.el8_9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 208927
     checksum: sha256:b9a60d012b2102ff8df1d03e949c13ffe1090e11a00422c16992cb897f1c50da
     name: libcap
     evr: 2.48-6.el8_9
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libcap-ng-0.7.11-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 81626
     checksum: sha256:1267aec0cd63a1487a9a103120656bd62a1f8ec64552e6438f10e58d086fe82c
     name: libcap-ng
     evr: 0.7.11-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libcroco-0.6.12-4.el8_2.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 500156
     checksum: sha256:327dbd1a9f48341e8f391c3ac809cfe68ea8f23091949fe92b810eefa015aa20
     name: libcroco
     evr: 0.6.12-4.el8_2.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libdb-5.3.28-42.el8_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 35289360
     checksum: sha256:b499193ca56c182b457f0fd6943f3a210f707997f722f95c20ca7e4a2361fba5
     name: libdb
     evr: 5.3.28-42.el8_4
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-23.20170329cvs.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 525171
     checksum: sha256:901bf3148d874bf17878d56ecbb524d1752a144164ca9c92891c181a3fccbfc2
     name: libedit
     evr: 3.1-23.20170329cvs.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libffi-3.1-24.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 960384
     checksum: sha256:5f1ecf2dd9b162c2d2d526918ac1a9d5f02d4f02dea1478f7cb25538bd0c7214
     name: libffi
     evr: 3.1-24.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libgcrypt-1.8.5-7.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2792226
     checksum: sha256:99734fb837bc7026c65eb15c0525f68288e73672fc2a3d583c3279786e47a13d
     name: libgcrypt
     evr: 1.8.5-7.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libgpg-error-1.31-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 921864
     checksum: sha256:6d5ca569e833217f8213e6607868d64a9c86c89770ecf3c4f1f260496461600e
     name: libgpg-error
     evr: 1.31-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libidn2-2.2.0-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2117426
     checksum: sha256:1fe11bb60d0913eb3c306a2092453c7079fcb71f1a0a5e5da3a51c4239111bfd
     name: libidn2
     evr: 2.2.0-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libkcapi-1.4.0-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 368458
     checksum: sha256:d6c0b8ea52682c8ed685ef44ded88c036f474a26a9107a47b23c20dd83b296d7
     name: libkcapi
     evr: 1.4.0-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 147827
     checksum: sha256:db3d53543d5caab48a6c0e582a8a5b4a00ae7a6b268e2b1231ce9de80f89ddd9
     name: libnsl2
     evr: 1.2.0-2.20180605git4a062cf.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libpsl-0.20.2-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 9190060
     checksum: sha256:80065f45ecdd72e97329a55786a7186b19204df1f485566eadf2e5810ff270df
     name: libpsl
     evr: 0.20.2-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 443269
     checksum: sha256:79048b406a5ecf7b97286cd72c5ab8f84f91174f1741db66b0e1a24a7de66113
     name: libpwquality
     evr: 1.4.4-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 654889
     checksum: sha256:322f0b9e2a909001e5e688b8ad52a5e6361ab350fa4fced3f446a6d1a3f2074a
     name: libseccomp
     evr: 2.5.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libselinux-2.9-10.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 355220
     checksum: sha256:2f61feb51798629d4f7b78130e68eb2516463da41d6e7b64d82d28d17355b3f1
     name: libselinux
     evr: 2.9-10.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-2.9-11.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 267435
     checksum: sha256:0e9bc0dd2ddcf5e8e8f734b32c7a3c93165060ef5b2f5910713984cea71e349f
     name: libsemanage
     evr: 2.9-11.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libsepol-2.9-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 562616
     checksum: sha256:98d64b940c64159d3e3a18e1b25cd7b9018563db56c9ecdc7d4f4481e4dde0dc
     name: libsepol
     evr: 2.9-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libsigsegv-2.11-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 463284
     checksum: sha256:a139e44850d9210e2a662e676dd57a6a40323b1744a14be7a87221f8e36cffe5
     name: libsigsegv
     evr: 2.11-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.9.6-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1151415
     checksum: sha256:a04fb32a5bdaf33053918c3c931891fe7415a8ace08069b74d055931413056eb
     name: libssh
     evr: 0.9.6-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libtasn1-4.13-5.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1968290
     checksum: sha256:c8ab521d0a15d78469b5525143fb7a5edb7db046a6eee1bdad3a51c4125ec852
     name: libtasn1
     evr: 4.13-5.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libtirpc-1.1.4-12.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 560689
     checksum: sha256:6bfcac057ab526f43b562f42b471f98c563456817bcda85cba058becccbee71b
     name: libtirpc
     evr: 1.1.4-12.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libunistring-0.9.9-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2058209
     checksum: sha256:41bf7f587637bc262a39720a9af0bd6c0132f75e421e69903f5418870335df8e
     name: libunistring
     evr: 0.9.9-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libutempter-1.1.6-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 32789
     checksum: sha256:cba58a16a506c2de446105f7b2c3e765d34a02941ea46d3ff03ed20c624f861f
     name: libutempter
     evr: 1.1.6-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 397339
     checksum: sha256:b6b19f09348381edcd692dda7c260a728d09c65f071d68ffed18de8f12eed403
     name: libverto
     evr: 0.3.2-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.1.1-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 229519
     checksum: sha256:d9803b5dd6cdbb4fd977258092cb50c48c8e28f3e3b4a0d6056c093983e17b29
     name: libxcrypt
     evr: 4.1.1-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/libxml2-2.9.7-19.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5483351
     checksum: sha256:7e50cdc6eb992d219955bbff31a2647a4ed00b088ad3fa16954947c3afd2c62a
     name: libxml2
     evr: 2.9.7-19.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/lua-5.3.4-12.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 437265
     checksum: sha256:764fa61f3a6678bf93d94351468e49863176420688ab4e8c1aa6a5eb84ecf23d
     name: lua
     evr: 5.3.4-12.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/lvm2-2.03.14-15.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 3182486
     checksum: sha256:eb51bc7200bf3af803093b3b61c543aae9560c36999aeca1304cd718b8bbe453
     name: lvm2
     evr: 8:2.03.14-15.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/l/lz4-1.8.3-3.el8_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 343953
     checksum: sha256:5952931f1ccd36d3db5bf1bb007966056e5fde6569a8d2da8e91b38bd9f41d3b
     name: lz4
     evr: 1.8.3-3.el8_4
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/m/make-4.2.1-11.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1446894
     checksum: sha256:19a4dbbf35f5ea28cfc2fd3f43ab01093f456804d1f94364121c025155f01112
     name: make
     evr: 1:4.2.1-11.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/m/memstrack-0.2.5-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 63665
     checksum: sha256:1eeeb865142626c458cf9659c88b400b9cb2cc9416e46baf740dff32f92f1cbe
     name: memstrack
     evr: 0.2.5-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/m/mpfr-3.1.6-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1153938
     checksum: sha256:1351024682b450c80c268a6132373bef0b7b35289d791f0fcca9385cfe3ddce4
     name: mpfr
     evr: 3.1.6-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.1-10.20180224.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 3422193
     checksum: sha256:6fcd8a8bc7eca36c65368df740a5760961740d0c34342cdb0eb23b54799948a4
     name: ncurses
     evr: 6.1-10.20180224.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/n/nettle-3.4.1-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1473768
     checksum: sha256:6c9f6c3e1a7d9bfc9b824cb4ce6e48e13698cea554504628564e0b4fdcfa5ac3
     name: nettle
     evr: 3.4.1-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/n/nghttp2-1.33.0-6.el8_10.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1589583
     checksum: sha256:9cf44c14ea0a908468049f7d301662e5ee1e0769b0ad144cae10b2a9158c2cbe
     name: nghttp2
     evr: 1.33.0-6.el8_10.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/o/openldap-2.4.46-21.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5853007
     checksum: sha256:42a8826001f6a49c1385746f1c5ef3967c3f15fe6fa510fe001d5a232732661a
     name: openldap
     evr: 2.4.46-21.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.0p1-25.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 3031156
     checksum: sha256:7a69d14debfacb701f4c71f9a17d41500d225397e3879f8027f729a9d4a259ab
     name: openssh
     evr: 8.0p1-25.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-pkcs11-0.4.10-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 520347
     checksum: sha256:a737e7fe890c5f53c1bc0c5925375791d8890f9d51c4a509091b41efa3f92861
     name: openssl-pkcs11
     evr: 0.4.10-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/o/os-prober-1.74-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 55171
     checksum: sha256:0577008638e1644fed230d55b221b485e6cdc702cda9c27cf74ab7adcb8b8f00
     name: os-prober
     evr: 1.74-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/p11-kit-0.23.22-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 909983
     checksum: sha256:9dece924ffd6e5698e7cb865f01976d7786b8c3cc65e743cf9ce3a856baff95e
     name: p11-kit
     evr: 0.23.22-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/pam-1.3.1-36.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1166826
     checksum: sha256:5a73a9d6ffbc3fa84853486a233e95765189dd0bf7b18059f2b8e763bfc8591f
     name: pam
     evr: 1.3.1-36.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/pcre-8.42-6.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1617186
     checksum: sha256:6d9f5c6ed81e5975723caa998de058df638dfadc33cc856d3a97c69db3180cb5
     name: pcre
     evr: 8.42-6.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/pcre2-10.32-3.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1671843
     checksum: sha256:bd60f4e4bf7bbadef2ff329112b5267da38a271af3c88fe53c57499c402c6670
     name: pcre2
     evr: 10.32-3.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-5.26.3-422.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 14612935
     checksum: sha256:846caf250e9bc506d779db0a1f94c181cb1278db67a89cfeb8ad9863cf8475a3
     name: perl
     evr: 4:5.26.3-422.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Carp-1.42-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 39410
     checksum: sha256:6e54cfe6173d114d79ad787616debfcd361215cb706a073849e5b725e9d602f5
     name: perl-Carp
     evr: 1.42-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Data-Dumper-2.167-399.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 133858
     checksum: sha256:693f45422bea04068b74e2006b6fe83ab28717c811a5010bf03d6dbc1971deac
     name: perl-Data-Dumper
     evr: 2.167-399.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Digest-1.17-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 22585
     checksum: sha256:ec3cc9dded5debede94ab5a1ac9635b9ce47378bdb759a45d6342ee1a1a3b3ff
     name: perl-Digest
     evr: 1.17-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Digest-MD5-2.55-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 60640
     checksum: sha256:e03a9fead12685a2190d6b01a1a81809a7bc7bdcba52dc8f3d9c099af12d0c8e
     name: perl-Digest-MD5
     evr: 2.55-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Encode-2.97-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1909992
     checksum: sha256:ccdb4f8262ca5564d92873e502108424e84ebc1fe2f87303c3f83abeaaa8b9e4
     name: perl-Encode
     evr: 4:2.97-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Exporter-5.72-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 30797
     checksum: sha256:4ebd569f83d0a04406c2784d4dcc06bc3aec02c47fcc315b2408b07f9cb6d7cb
     name: perl-Exporter
     evr: 5.72-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-File-Path-2.15-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 44093
     checksum: sha256:d067cc6c5f63792fd0167bee1235c2e7b041d0724383ac65d1a275c92e60ee7d
     name: perl-File-Path
     evr: 2.15-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-File-Temp-0.230.600-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 89704
     checksum: sha256:aef94fc3f0fdc16f4332c1d44c05bf96abd821a35a5645dc7df98159563fde23
     name: perl-File-Temp
     evr: 0.230.600-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Getopt-Long-2.50-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 55481
     checksum: sha256:78e26ca8558531b08df38b63ff09b15a1237f57693cfb191dff6b123b52ad462
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.074-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 94643
     checksum: sha256:ee584d582dc268ceefd1c334f19178df24d15e2bbf3fc4db3408d8baf7ba1156
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.39-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 60059
     checksum: sha256:474c2d5388faea1a2a958d803754276dd99105a5e446200aebca09e0cb16445e
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-MIME-Base64-3.15-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 28234
     checksum: sha256:ed1d5e3edc2c0e83cfe4f4db09ffcff50b6a70d91ccac2856b2024c9261351f9
     name: perl-MIME-Base64
     evr: 3.15-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-PathTools-3.74-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 137742
     checksum: sha256:07efbd3dd8efa238a61845f2e8328836208344c58b3cde763ed726ad9f66e53d
     name: perl-PathTools
     evr: 3.74-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 21369
     checksum: sha256:c7d6b9fd27c89bb9607dc6870be25816af5f75a98955539570250077f3e13c58
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 170889
     checksum: sha256:300bdca3d858f534ad829cd9b8c762c5b34cfad11c31d70ee6beb9035f07cbeb
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Pod-Simple-3.35-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 292502
     checksum: sha256:865ee9e5c0dfb5ad3cd83eeb9b35082d6d51b1c9a18e80e6e4121710f6321663
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Pod-Usage-1.69-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 74242
     checksum: sha256:eafe281a2099a0dc407427cfa56696f460a0635f34e2233c019ae0bc0fba245b
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 103833
     checksum: sha256:ffb0c86b10d1103123df63cc0328d09315db6b03802f2614a96fdd7232444803
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Socket-2.027-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 61493
     checksum: sha256:f4a44ab8183b9172652f9c749a184410b5067c8cc6656a35c4eb12c6c4cb8a52
     name: perl-Socket
     evr: 4:2.027-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Storable-3.11-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 212600
     checksum: sha256:e5b897cf73b34d9f121366108a56d4c9b3cc5b4feae9216d06a1ea9faadb8a1c
     name: perl-Storable
     evr: 1:3.11-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Term-ANSIColor-4.06-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 63153
     checksum: sha256:6c78167c38a6fcc475392ccb60dddba5ec7aea6d4c9ccc8fdaea6066611a3c23
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Term-Cap-1.17-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 22600
     checksum: sha256:2953646cb9447ea6be598bbf750521016967d09cbee580e7177fb14b1fec49e1
     name: perl-Term-Cap
     evr: 1.17-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 19141
     checksum: sha256:04dce7752e55622eb65ff504b4f43190e1104fd7bd0fa6f7d0a08b99c35f6827
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 30141
     checksum: sha256:ee70aff3a8052cd9a2c42332a8514883e0453f1cc4b51283a8f0213fd2a50e6c
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Time-Local-1.280-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 52203
     checksum: sha256:37a06155836500c22854a0ed2cd1e19e2cb9464eafef8e2b72159923a13b9aa7
     name: perl-Time-Local
     evr: 1:1.280-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-URI-1.73-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 126236
     checksum: sha256:dad920c0cd599360aff44efb33d8de6245b937dd296b011c645db1464fcc4ce9
     name: perl-URI
     evr: 1.73-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-Unicode-Normalize-1.25-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 51863
     checksum: sha256:26df107448834f5b2def4c6cd609298c6bbbfe3220f8077664158f2a20581f73
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-constant-1.33-396.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 32690
     checksum: sha256:976f9c6ee5780e4b70a1a712516ff0e1c956ebb47bcd2616fbbb536520bbc328
     name: perl-constant
     evr: 1.33-396.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-libnet-3.11-3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 106574
     checksum: sha256:dc91b0b1230e700b03f6bf9b67e7e1888a40fb3cba04407be800ebe03b3f6632
     name: perl-libnet
     evr: 3.11-3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-parent-0.237-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 27591
     checksum: sha256:08815783344cfa0bf276838b3ed36e3df7c6d854a350c6515f8585d2aceef5f6
     name: perl-parent
     evr: 1:0.237-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-podlators-4.11-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 146297
     checksum: sha256:5400b164b06ffb22a71c9f784bb8d2a8ca1f337a0444eb7072383fd5c0b4cc50
     name: perl-podlators
     evr: 4.11-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-threads-2.21-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 129508
     checksum: sha256:d87b4593b6b3aa2edf6caed1693b5f20af1e9998cfd2cd94246f30bb15257653
     name: perl-threads
     evr: 1:2.21-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/perl-threads-shared-1.58-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 116865
     checksum: sha256:f4d768aa34f6bfbe9985856bf5188c2dd7b02f99b415343ef135335d0e86e8a1
     name: perl-threads-shared
     evr: 1.58-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/pigz-2.4-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 111085
     checksum: sha256:25eb0a7a95c2f45dddec4349fe6c5e81399859295954d44f0fbdfd849d593d06
     name: pigz
     evr: 2.4-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.4.2-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 300577
     checksum: sha256:2bbbbb503f27488cc66f935cd31a14f1eb01cd9e5fb9d52260bacdea663abb1a
     name: pkgconf
     evr: 1.4.2-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/policycoreutils-2.9-26.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 7122315
     checksum: sha256:c3fa01ec896e6e30d1a27244a0c0dfab3ea733cfc2c519698899cf1c0dfda03f
     name: policycoreutils
     evr: 2.9-26.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/popt-1.18-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 596391
     checksum: sha256:bd40809646317352c305974bc1204064b1492de90718b61b738548307cde1ac4
     name: popt
     evr: 1.18-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/procps-ng-3.3.15-14.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 948787
     checksum: sha256:f7c6882f91e993ebdc97259a7ef0fe42dd9f98b34226bb8ee89b4c8a8d778abd
     name: procps-ng
     evr: 3.3.15-14.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/publicsuffix-list-20180723-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 86231
     checksum: sha256:696b5b556ecdfd7649e9275e20e5ff7b191b30631e11dadc93853de860f5ed4c
     name: publicsuffix-list
     evr: 20180723-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/python-pip-9.0.3-24.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1380608
     checksum: sha256:0c18dcaadf6e9596e2b939ae9cc75db12df7919a01a204f314df315e384b0d4a
     name: python-pip
     evr: 9.0.3-24.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/python-setuptools-39.2.0-8.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 868530
     checksum: sha256:cd563238ca4ec7c288874e42d1506337e4917620ed83b1e4a2aec2fb6a5ea770
     name: python-setuptools
     evr: 39.2.0-8.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/p/python3-3.6.8-69.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 19223254
     checksum: sha256:4578b972df16aa25dae9170d339d86792c59612f29e0726ead0107ed7347ba3a
     name: python3
     evr: 3.6.8-69.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/r/readline-7.0-10.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2937518
     checksum: sha256:d35c049106cb1377d5c13f2d8dd508c035bdbcc8b0cf15c9fa41dad0c946c89b
     name: readline
     evr: 7.0-10.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/r/redhat-release-8.10-0.3.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 58701
     checksum: sha256:9b36cf3d7c42a8663017a44e4ae42cfcea0837dc416746f26238b1284a291230
     name: redhat-release
     evr: 8.10-0.3.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.14.3-32.el8_10.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 5269921
     checksum: sha256:b43436849f8b9fa3dfe8e42e87e814906f0cae191f9d159ea24ec9732d379d58
     name: rpm
     evr: 4.14.3-32.el8_10
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/sed-4.5-5.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1358944
     checksum: sha256:f455a908d552d720431cbef8af08ee44004b6d7b3d1a1768de99c117a718c8c8
     name: sed
     evr: 4.5-5.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/selinux-policy-3.14.3-139.el8_10.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1934638
     checksum: sha256:da1784cbc92552eec7bc06125079a729d8bf62a53e2378f6d67a9f6705e101b8
     name: selinux-policy
     evr: 3.14.3-139.el8_10.1
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/setup-2.12.2-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 220230
     checksum: sha256:72f87a1c0c92c9486bdb3748db880281fcc1f947bbedb99edbcebf189e4a5c40
     name: setup
     evr: 2.12.2-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.6-22.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1845120
     checksum: sha256:140a4273738ea9cfd1fc5627ebd66ad1696a5e3c959092b41bf5dc6d7657d8a6
     name: shadow-utils
     evr: 2:4.6-22.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/shared-mime-info-1.9-4.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 644720
     checksum: sha256:b070925e9e0d4824b3c0ed86bad64f77daf954ec359260789fe8f8150ef402c6
     name: shared-mime-info
     evr: 1.9-4.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/sqlite-3.26.0-19.el8_9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 23592377
     checksum: sha256:d4bd6ea502814941a714ab1f40e87d8f48fc4a362b344ca928f3c2f514fdf024
     name: sqlite
     evr: 3.26.0-19.el8_9
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/s/systemd-239-82.el8_10.5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 9161850
     checksum: sha256:a20ae7bd2f13fd756b2389ec6ba6f84e6a9be28df01b5a7d04dab93b492a0eab
     name: systemd
     evr: 239-82.el8_10.5
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/t/tar-1.30-9.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 2169236
     checksum: sha256:53ae8ab2f98cb36c9d7e3830a7a8d6a9897707bf3d0f0c6805282f88ca6e23f7
     name: tar
     evr: 2:1.30-9.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/t/texinfo-6.5-7.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 4544531
     checksum: sha256:94881acbdc6de2e2e22c7fac12ca732da89b2b6d245ca9f8a5810387090ccb76
     name: texinfo
     evr: 6.5-7.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/t/trousers-0.3.15-2.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 4722437
     checksum: sha256:ad79eab11673ac2f172276a993d98f2bf98c77728863f656d7cc0ab595d5b593
     name: trousers
     evr: 0.3.15-2.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 946701
     checksum: sha256:2f0ba51d371713287a690d9d1635b534113258aa2571862603d52870c1c8b60d
     name: tzdata
     evr: 2025b-1.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/u/util-linux-2.32.1-46.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 4816801
     checksum: sha256:3fb688481dd062d917d8119cd64582a9e6ffa6736a6dbbf956d038a9115c6004
     name: util-linux
     evr: 2.32.1-46.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/w/which-2.21-20.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 171457
     checksum: sha256:70aca3ef4713172514dbe5334bd56b29a988e736211e946219f5d965b31eebce
     name: which
     evr: 2.21-20.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/x/xz-5.2.4-4.el8_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1077113
     checksum: sha256:7914b320eefa2db6dad68e5f01e99f8e661072a1f13acb3d19cba8c1295ae40a
     name: xz
     evr: 5.2.4-4.el8_6
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/z/zlib-1.2.11-25.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 565905
     checksum: sha256:d632ef6e133e08c97258fdee1642a3c24106aa03f80e3c190a9d24be8669da7f
     name: zlib
     evr: 1.2.11-25.el8
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/source/SRPMS/Packages/z/zstd-1.4.4-1.el8.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-8-for-x86_64-baseos-source-rpms
     size: 1973262
     checksum: sha256:df48591f05ff68cbf8dc8ad48c814e14ed39866511b14933a1c0ab1c3fec5469
     name: zstd
     evr: 1.4.4-1.el8
   module_metadata:
   - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/repodata/b7fd1165a4aa176536dc6e4ced3416777fc96f033bde074e95fb2afbe514df05-modules.yaml.gz
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-8-for-x86_64-appstream-rpms
     size: 730550
     checksum: sha256:b7fd1165a4aa176536dc6e4ced3416777fc96f033bde074e95fb2afbe514df05

--- a/konflux/el9/rpms.lock.yaml
+++ b/konflux/el9/rpms.lock.yaml
@@ -5,1554 +5,1554 @@ arches:
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/c/container-selinux-2.235.0-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 66501
     checksum: sha256:0f6744a8994f03a54b437bc601d4bf734992b78ebc428a9907c330f0e246903e
     name: container-selinux
     evr: 4:2.235.0-2.el9_6
     sourcerpm: container-selinux-2.235.0-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 9618370
     checksum: sha256:03758628df2352ad0e3e08431ec3f49fc5d78ace61252ab6e2b3fdd1b953d406
     name: cpp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/d/delve-1.24.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 4618655
     checksum: sha256:b3af19ee9dae03835e25613f6397f61ab8ad04726e77bcbf466c7e5a280aefef
     name: delve
     evr: 1.24.1-2.el9_6
     sourcerpm: delve-1.24.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/e/emacs-filesystem-27.2-13.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 9758
     checksum: sha256:624b6683efb3e254eb8f44a927772ec251a841803b7f693f9c6ad0651e694557
     name: emacs-filesystem
     evr: 1:27.2-13.el9_6
     sourcerpm: emacs-27.2-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 216324
     checksum: sha256:f44a17730803f53266874678031b8121541b5b1a8047a3205c2576630216f468
     name: gawk-all-langpacks
     evr: 5.1.0-6.el9
     sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 29056841
     checksum: sha256:0fcf323be8d8b1f9debf35a7cfd37fcf9ba9e724d7f61159ae947d9772867e2a
     name: gcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/git-2.47.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 55473
     checksum: sha256:25c3f245250e7afbb72088f8a93da76f1b8c1048aea55a320db7afed1d60dd46
     name: git
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/git-core-2.47.1-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 5421632
     checksum: sha256:eae7ccd8c2a05a4b8991a06ed23276af95d1755665ec97d2bbd7e60e58b2c164
     name: git-core
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/git-core-doc-2.47.1-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 3194257
     checksum: sha256:172dd65142fcd6548658a47e46d06a9a80251ab7a2cd6da6a0a99bb92e83cb56
     name: git-core-doc
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.14.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 575390
-    checksum: sha256:80740f572a9e7cde10f6d899125768f74f7766bdb2b5d2f67a7bad3a14118913
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.19.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 575090
+    checksum: sha256:8d228bef6d312ea43cc4efad9bf33c153fd46f346064a519e05b479acad17bb5
     name: glibc-devel
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/go-toolset-1.23.6-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 11349
-    checksum: sha256:0a7a891f7d7b4d856b48bbf2a2c0b47781f033d7d92b1f51885474804c83c841
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/go-toolset-1.23.9-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 6941
+    checksum: sha256:589abd9d7b4816b90b361e65c97279f888b82512d494948a96ec6553e11cee12
     name: go-toolset
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-1.23.6-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 700123
-    checksum: sha256:945d233aea40622e431e8c8cddaecb9fda6040746e92cf8cedd5082fbf31e82b
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-1.23.9-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 695420
+    checksum: sha256:b8c6131f79d60a7a7d015398ce6c36fad3eaa077d6f9a7ca84362e8b99b55bb6
     name: golang
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-bin-1.23.6-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 61953342
-    checksum: sha256:0c42c43accda247bc92f4f527a03bc30e7a7d10458f800c449a0cf249e0e169c
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-bin-1.23.9-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 62012148
+    checksum: sha256:c550e602e63a11faba5da481c1e4d02acc2a6ff9aa3ac4f391ce32d10dbda9e8
     name: golang-bin
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-race-1.23.6-2.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 192575
-    checksum: sha256:41c38bcbaee8f5593f671b324f26a72a7858bc60054719399cf19c9c1bb9c41b
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-race-1.23.9-1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 192045
+    checksum: sha256:764c986b4934f99a29a3035afcbfa0c66bf084acf6add5dbf5c957421430c33e
     name: golang-race
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-src-1.23.6-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 11302169
-    checksum: sha256:8c5a8b16db661b76afda382c55749692277a3fd7482a4ab4838822e467c7560c
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/golang-src-1.23.9-1.el9_6.noarch.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 11297588
+    checksum: sha256:3712d0ba4ede1c0aa2e7cfd4384cbb7378de4cbd355a1ad91b1dcdfbc3bdd03e
     name: golang-src
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.18.1.el9_6.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 3665225
-    checksum: sha256:ea88e99d3237c74bba2f324758b2e8921e95a581b6f79cf9f680cfa061bd6700
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/k/kernel-headers-5.14.0-570.22.1.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 3668937
+    checksum: sha256:92f279b1166dc1687b3e2a0770355e0da687da96a6b1c4ba90cb97daf3defa45
     name: kernel-headers
-    evr: 5.14.0-570.18.1.el9_6
-    sourcerpm: kernel-5.14.0-570.18.1.el9_6.src.rpm
+    evr: 5.14.0-570.22.1.el9_6
+    sourcerpm: kernel-5.14.0-570.22.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libasan-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 445773
     checksum: sha256:eafcdab019e14b3f7f575f8bf66b611b26f1f77193cfec767401e92fd1f1e2d9
     name: libasan
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libmpc-1.2.1-4.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 71343
     checksum: sha256:12c0bd83a7321dccd6c715d149cb6f12299e13a1e09732a629003b0140ad9b32
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libubsan-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 206381
     checksum: sha256:2600776467b51152b8b7fb7e498d2d7564b5a1b3c13eb5268804ef104429c3ba
     name: libubsan
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 33082
     checksum: sha256:0897868b5e5ab66225dd55f585076975a84e3fd68b93a38be1d8a231d441bc16
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 4649573
     checksum: sha256:ccae65d7caa28b81158b799a434263aaa92fd693119f7145a73b7490633eacf1
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-B-1.80-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 191958
     checksum: sha256:62d9b65ee4fed04ca820478adaea55b81e43b63d3a48d46fe5bc8f3664e61f84
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 60918
     checksum: sha256:ddd2f1958bd1a5e0c555ef401a04800d72b9807e11c2a3d76af004f0a38d5985
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 40716
     checksum: sha256:4ef3aef6190cf64e16f9c784e2b1560a51aac62b4381cef7492c8042e4122273
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 26404
     checksum: sha256:50d425f0bd83cad488ac63f20a06c97eda7d302bef995e532ddde6ebbf2b0270
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Encode-3.08-462.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 1818588
     checksum: sha256:000879773b1a093fd747fae52a31a6d866339a2091a6b94251fb64bb29778da5
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Errno-1.30-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 15307
     checksum: sha256:2818bccd362516666bd66b2bfe6127e67d5b83ad885880ecbbaaad2935818cfa
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 22394
     checksum: sha256:bbdca1fd4e06299c24bbdcd91b3d4710c74ec763c30ba8a0865b533fb80490ea
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Git-2.47.1-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 40089
     checksum: sha256:3bb2b9b3f197bb548455a5ed7304ef25510f4ae6f4ee92dd4db74946a869442e
     name: perl-Git
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-IO-1.43-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 95162
     checksum: sha256:bf134d3f62ddec035b321f68c22610eaaef7adfb15c32e6364d68a93d3c07bfd
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 35880
     checksum: sha256:c2f794f16a865b6ec6c0379c8dc09a0227e52fca37158543a0011ed22d29c366
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 23474
     checksum: sha256:4846f53ea3b2b2edbfc76a8a0d9b9faeda4b306cc0e5c7d3ff0f4a51d80da837
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 437663
     checksum: sha256:dc5783ce9dcdc6eec44801ecac3ba51ebabafa31081aed0c084ec9c165249c5a
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 102733
     checksum: sha256:23190f00150ef9c300bf00d21b4afc4c0f74d3cbe539a26b9515ef551041f679
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 95133
     checksum: sha256:13167c7dcf4ecbc9136f0f1ea6923f1abf67f59f520fccd22cd462cf7c4eeaee
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 79754
     checksum: sha256:1548e1dc1a3e6c35a0a3065bd9ff1b9c7fc6f2c028c03e2f59fd7319a87b65de
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Socket-2.031-4.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 60171
     checksum: sha256:b18817cb936f736231166872928ac4a10418b42e9baeeeb93a4304d1764c0530
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Storable-3.21-460.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 103710
     checksum: sha256:55e3f3536cad3677ee99ac54705dc6075fc938e17b453410ff383932fc93c6da
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 41994
     checksum: sha256:c94ebcc34f23bd1caef2e64456c47a9a5bc21de163719fa6bdefaeceeec5f435
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 74796
     checksum: sha256:9b3304229945377f9556d758ee1113daaefa1faa547b70b0a7a799daf1e22af0
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-lib-0.65-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 15300
     checksum: sha256:2e49d99e447b970599649b8419f673f64b241a892046113c0c72c3a756a338b4
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 2372060
     checksum: sha256:12c795f320750181649b5857516709777b709e251cea99b4874f92e47345b6a4
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-mro-1.23-481.el9.ppc64le.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 30619
     checksum: sha256:efc516137cc2e1b524a15b819a62a39171e2f7f3dc8142e9c579e30340cb9ce9
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/a/acl-2.3.1-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 79564
     checksum: sha256:5abf618a32e0cfd20a2402b5b383e0d8055dd61c958bd1df066f5ab868358b63
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/a/alternatives-1.24-2.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 44269
     checksum: sha256:ff47094c1f94e74225bffd2b93cd3b4690d1e20d098d35ecf2cccecd468f6f62
     name: alternatives
     evr: 1.24-2.el9
     sourcerpm: chkconfig-1.24-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/a/audit-libs-3.1.5-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 147214
     checksum: sha256:afc05fd65d046f162e4acd5ff9250798138736dcc151d4993b1f4e2684e81eb2
     name: audit-libs
     evr: 3.1.5-4.el9
     sourcerpm: audit-3.1.5-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 8229
     checksum: sha256:f498b0813fa1a825d550e8e3a9e42255eabfa18e6fc96adfc6cc8fa7e16dd513
     name: basesystem
     evr: 11-13.el9
     sourcerpm: basesystem-11-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/b/bash-5.1.8-9.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1818376
     checksum: sha256:4ea13d08a909851376ff25b706c942eb3b66b0205e980aa4f9176e28ee1bae37
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/b/binutils-2.35.2-63.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 5199630
     checksum: sha256:ff0fe53687a6e04f7e6283215300bae116d4a372976354dab0feadae5ce51175
     name: binutils
     evr: 2.35.2-63.el9
     sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1068913
     checksum: sha256:d5b6d1537be6d6c2828476c21eccac5352f6a730831ee6206f39d42b6990fdc9
     name: binutils-gold
     evr: 2.35.2-63.el9
     sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/b/bzip2-libs-1.0.8-10.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 47605
     checksum: sha256:f1b07f02b34fe8d8ba24eed9afd874ced25f4da14eb1b0c804e47de1281fce49
     name: bzip2-libs
     evr: 1.0.8-10.el9_5
     sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1044629
     checksum: sha256:fda07ba8aa8afd38800aa1e49ddd4c7916d8f67030739f85f59727f47bdf28dd
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-91.4.el9_4
     sourcerpm: ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/coreutils-8.32-39.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1285039
     checksum: sha256:a224aa371dcbbed053c88e6b25bc503042cc846e7930653bc9613525a109850f
     name: coreutils
     evr: 8.32-39.el9
     sourcerpm: coreutils-8.32-39.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/coreutils-common-8.32-39.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 2113510
     checksum: sha256:37184551765997ac05d0e57c7398ddc8ead42df86d8352ca7b73a05c8ad91a88
     name: coreutils-common
     evr: 8.32-39.el9
     sourcerpm: coreutils-8.32-39.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/cracklib-2.9.6-27.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 102420
     checksum: sha256:be3738f99a18e14c80b771e0bcc4e13d9d067f1a1bcefd9ffcdabdb5e03bf46a
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 3821001
     checksum: sha256:a5ae48064c709f448291de88bbf97427c65cc6a03179972496d27d4223bb6e96
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/crypto-policies-20250128-1.git5269e22.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 92144
     checksum: sha256:e3ca18b4805fe8624d7d884859c167c14f48a4a1565b75403bb7470e7132cc1a
     name: crypto-policies
     evr: 20250128-1.git5269e22.el9
     sourcerpm: crypto-policies-20250128-1.git5269e22.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-31.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 307948
     checksum: sha256:cd9399dfcdc54266829c99ffb40e9fc01a2cbf127697e0a1d84719b07c300240
     name: curl
     evr: 7.76.1-31.el9
     sourcerpm: curl-7.76.1-31.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 887955
     checksum: sha256:982a47af9468cba2e570cf771fdf56bb9abb206fb6fcd2c7ce1ac55b031f08e1
     name: cyrus-sasl-lib
     evr: 2.1.27-21.el9
     sourcerpm: cyrus-sasl-2.1.27-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/d/dbus-1.12.20-8.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 8053
     checksum: sha256:2fc6ba643a8f1eb9d11987ed1b9c00ecefce1f4a4de2935676c4989d0f4574d6
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/d/dbus-broker-28-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 192179
     checksum: sha256:dfe710f3a07cd31fd144f439deaed0ef78b5ea65caecb754bc69959908191af7
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/d/diffutils-3.7-12.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 426776
     checksum: sha256:1e58188524109f7f021d2a4a7b7ac5ab9ecab60dba1b1a0defc950a0f3b91f64
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 49674
     checksum: sha256:416fc0d0f42b1e71ad33f21cf7f96f0722c5714d6f70042cb86513792bbc9b69
     name: elfutils-debuginfod-client
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/elfutils-default-yama-scope-0.192-5.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 9839
     checksum: sha256:fb2fe6a8f7552aecda6c998adddb0f88264252b6f717a306adfd0c24b0e33e79
     name: elfutils-default-yama-scope
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/elfutils-libelf-0.192-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 219509
     checksum: sha256:84022222ff03a84f18a7fc7e4f12a228bb050ee0fb332e40b2e1d3b723755164
     name: elfutils-libelf
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/elfutils-libs-0.192-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 308723
     checksum: sha256:307bacf89fc4d055182d1fa4dd67d54ae526f480517fc228af348fe7884facee
     name: elfutils-libs
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/expat-2.5.0-5.el9_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 127290
     checksum: sha256:d2b0e91d162cedf8e6b68c82795eec1553ab15618862b2717139fedc27586953
     name: expat
     evr: 2.5.0-5.el9_6
     sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/f/filesystem-3.16-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 5003944
     checksum: sha256:e7d0bd8df20dfb2b499634c34ec966e1bd477a5d15f98373f56089ed0f387aca
     name: filesystem
     evr: 3.16-5.el9
     sourcerpm: filesystem-3.16-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/f/findutils-4.8.0-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 603076
     checksum: sha256:d4662cea7b9ae75c86e6afa1c69b3047773acf7d4a6cf8b99e63355cde0e8de8
     name: findutils
     evr: 1:4.8.0-7.el9
     sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/gawk-5.1.0-6.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1064251
     checksum: sha256:b0cc389ad0855900c79f2cfa525df8cbc663093056b0b5d29ec3e36a189b325e
     name: gawk
     evr: 5.1.0-6.el9
     sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 65838
     checksum: sha256:18bdea48a00d647410ad82fc2cd8da81124611b1b2dd21a5526ba7e433c52be0
     name: gdbm-libs
     evr: 1:1.23-1.el9
     sourcerpm: gdbm-1.23-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-2.34-168.el9_6.14.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 2850078
-    checksum: sha256:ec4e6785c81de329ff2c5eb3675161de0cf5c6e35e02699b5ef63916863572e7
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-2.34-168.el9_6.19.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 2850313
+    checksum: sha256:1dcae0f2af3d8d47da669262a75bb1a820e5762b72d53834bf568f1105c85d67
     name: glibc
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-common-2.34-168.el9_6.14.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 328372
-    checksum: sha256:4f50d7ff1f348ff8b8ee3c3949563e275b1a0bd123d2e6347456b690a16549a1
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-common-2.34-168.el9_6.19.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 328063
+    checksum: sha256:031168ad9d99cb99e7d96b4b1ef337dc906275093863681c0f22a1c735a3833f
     name: glibc-common
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.14.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 1820588
-    checksum: sha256:8bfae30dc34a43907b970deb9b90bbcfa7c170f6e68a8678a1a20bd7fdc41686
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.19.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 1821401
+    checksum: sha256:7c3ce94c2e05a7d1371bb7f143f4a85a7a0d154217ec478c318685ce60b6f285
     name: glibc-gconv-extra
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-minimal-langpack-2.34-168.el9_6.14.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 19985
-    checksum: sha256:8d9dff368110828fcf50832c5946e4da70427cee1883e21f106d08fee8f5a278
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/glibc-minimal-langpack-2.34-168.el9_6.19.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 19709
+    checksum: sha256:6c13858a066349a5a155965abdfea642a061fe28b622340f06be3cfc6e12bbd8
     name: glibc-minimal-langpack
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/gmp-6.2.0-13.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 312805
     checksum: sha256:aeaf0f125933153cc8fc9727dac28dade4c6a8ae146812c4445643dadd3a585c
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/grep-3.6-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 288035
     checksum: sha256:3598703d7995b01b5b10f55ac65ce851e30f41d037e679bec4afa11a41846511
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/groff-base-1.22.4-10.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1156956
     checksum: sha256:cde885d7a5414a62086ce1eb0edec90958fe2f53cb3f02ee08ce600c728acdee
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/gzip-1.12-1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 175705
     checksum: sha256:55b983f08d8b2a0741b07f114cdba89a8ecb207064c001e90e4c76a13836d458
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/j/json-c-0.14-11.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 49418
     checksum: sha256:e8d46e2dfa41daf9d8fb8928008057db9eed5ac764f68d3ef54c051a124a2ea9
     name: json-c
     evr: 0.14-11.el9
     sourcerpm: json-c-0.14-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 35505
     checksum: sha256:6e45fee51e67239d8550789a53ab7ca562c605513afe0ff890786ae9fff8fac5
     name: keyutils-libs
     evr: 1.6.3-1.el9
     sourcerpm: keyutils-1.6.3-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/k/kmod-libs-28-10.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 74774
     checksum: sha256:36662cf4a8490e7044db68a488c564c97a9fbf2b1f15ec8793d26633dabbddc8
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/k/krb5-libs-1.21.1-6.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 870474
     checksum: sha256:85cf8c2ea207d0a03cdc53c96ac4f97f32a1c686f6da2ec843805be10299530c
     name: krb5-libs
     evr: 1.21.1-6.el9
     sourcerpm: krb5-1.21.1-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/less-590-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 182590
     checksum: sha256:909dd6dcef9eb24629013e063d8abd4adbb99fd73c15b01a4dffed17791cb473
     name: less
     evr: 590-5.el9
     sourcerpm: less-590-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libacl-2.3.1-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 26589
     checksum: sha256:3612c4b0b3abab058e19ff290b96147ccbbd8179317a8d51f9ed78958d982b4a
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libarchive-3.5.3-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 469399
     checksum: sha256:d15f170b728c03aa9e21933c8a30b6b4011a29250a56495330a0a1337b8cd3b5
     name: libarchive
     evr: 3.5.3-4.el9
     sourcerpm: libarchive-3.5.3-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libatomic-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 29806
     checksum: sha256:599e48d6be7ac1d98cff4b11323d9a5d183d1898dd7e4505c025b4bfca45bb9b
     name: libatomic
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libattr-2.5.1-3.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 21501
     checksum: sha256:a2398158adad2016fca3d0d2c272e027b8279020992a349664caf6a2299ec50b
     name: libattr
     evr: 2.5.1-3.el9
     sourcerpm: attr-2.5.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libblkid-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 128296
     checksum: sha256:a781641732ffb6535d5cbfbc0b78956bdd5878ec94f49ad11f0f688bc0e9fcba
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 347425
     checksum: sha256:7f1571cb99807f3d06d2d1cf9b9c804a7d3e773f1ac6828871aeddcb8900c12b
     name: libbrotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcap-2.48-9.el9_2.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 80588
     checksum: sha256:06beaf8fd04840c2c962eb7effe14a9f41de575ba6135004d255b3af63109cea
     name: libcap
     evr: 2.48-9.el9_2
     sourcerpm: libcap-2.48-9.el9_2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 37600
     checksum: sha256:2483f8a4b41d76f84939855b712cfa8a990254ac36fc590daa641b2c19b014eb
     name: libcap-ng
     evr: 0.8.2-7.el9
     sourcerpm: libcap-ng-0.8.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcbor-0.7.0-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 62130
     checksum: sha256:c18f6560c02f3692d8fea54dc89548d4fd183cb7f73ef3ef7e0cf2f7d1815a47
     name: libcbor
     evr: 0.7.0-5.el9
     sourcerpm: libcbor-0.7.0-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcom_err-1.46.5-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 28844
     checksum: sha256:9e5bc6d74d50887d4ae0245dd51a25981f151c87fe76b0a5bc196a79cbefce11
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcurl-7.76.1-31.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 324514
     checksum: sha256:f065d17d8f7ebb4469d267fa9bf796fc302e8ef767a31e38db7e7f09961cec2d
     name: libcurl
     evr: 7.76.1-31.el9
     sourcerpm: curl-7.76.1-31.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libdb-5.3.28-55.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 827261
     checksum: sha256:999f2d8e844a135dd0b751e5a2dc4dd278e72a989dd795c0bedac8c152a0eee6
     name: libdb
     evr: 5.3.28-55.el9
     sourcerpm: libdb-5.3.28-55.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libeconf-0.4.1-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 32878
     checksum: sha256:a3fbb9481c4d4f13cc1f1593a83f31fc27975b759fd01235b875d09973eeb102
     name: libeconf
     evr: 0.4.1-4.el9
     sourcerpm: libeconf-0.4.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 121673
     checksum: sha256:ce0039b9b7d363df74541da164ebccde85a40f083f5b55382325db6584bc693c
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 287857
     checksum: sha256:bc6eb253e6cf0e06fa7270c029502e14ee70cb22c2ed86b15f2a9952ba2f375f
     name: libevent
     evr: 2.1.12-8.el9_4
     sourcerpm: libevent-2.1.12-8.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 174570
     checksum: sha256:966d0ccb94752aecca93368a9541e2dc2bb30db9f2cc6aeb6ab524e32b39b1bb
     name: libfdisk
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libffi-3.4.2-8.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 40799
     checksum: sha256:c5042688cccb346b2bb0865410564d305a9b86e7618558354428ebc09ff689d8
     name: libffi
     evr: 3.4.2-8.el9
     sourcerpm: libffi-3.4.2-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libfido2-1.13.0-2.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 112104
     checksum: sha256:9899776f2483012e06cad4d7a298b59b2a0ddf1d3226012db7559f00178c81d2
     name: libfido2
     evr: 1.13.0-2.el9
     sourcerpm: libfido2-1.13.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libgcc-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 78032
     checksum: sha256:8c96e34373c8068f489b07f0e1dec9731b9d600d6125839b2367211c491ec01a
     name: libgcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 612983
     checksum: sha256:917a9fc0eca0405813697b4d830578c92b01c1dba766321bfa880a248b0c4d5e
     name: libgcrypt
     evr: 1.10.0-11.el9
     sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 281190
     checksum: sha256:5d693c13bc37de1de427976bcc61375d5bbb5880c1ecef9d9db22c300cae8ab3
     name: libgomp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libgpg-error-1.42-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 234885
     checksum: sha256:2db222784b8d4183fd2704cffa9df4d7023ebd5dc51806fbdc30e8fa9123c5a5
     name: libgpg-error
     evr: 1.42-5.el9
     sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libidn2-2.3.0-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 110270
     checksum: sha256:28a3da7752093735a9c0de6232bcb6c3d9910a90956891396712825b354bf7d5
     name: libidn2
     evr: 2.3.0-7.el9
     sourcerpm: libidn2-2.3.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libmount-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 157123
     checksum: sha256:63ad2d7727a60d7c392a6261b3e3c9f9e30ef9056636727b3169d8a53927f91a
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 85990
     checksum: sha256:6f9c2190323d33ec5d9355965971a6d5423fb233d152f95b91a6e7b3b80ab584
     name: libnghttp2
     evr: 1.43.0-6.el9
     sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 42712
     checksum: sha256:a96600fec79e7d94523816dc620203e812c4a08c82c07fb3bb62d7e9e6e1f661
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libpsl-0.21.1-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 69346
     checksum: sha256:dfdaff3aa507721d913aae308caa7b672a952e1d21485958daa749b2d1793fc3
     name: libpsl
     evr: 0.21.1-5.el9
     sourcerpm: libpsl-0.21.1-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 128350
     checksum: sha256:0b13ff548b9b0be9f8d0271d90fa3673c081fbc22dc869ae4c37c68fa2a32c09
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/librtas-2.0.6-1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 86335
     checksum: sha256:64d105e7f8b9ee542efe65816ae77fb38988c00bef1e0cc5ea3e1a4e89fb7505
     name: librtas
     evr: 2.0.6-1.el9
     sourcerpm: librtas-2.0.6-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 84378
     checksum: sha256:ef769ff2877361cbce88aac5e35091e9798c7cc23f91f12637b1a4229e056ea6
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libselinux-3.6-3.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 102114
     checksum: sha256:ca29ae2f3e2ed004aafca74bd18a97b5e987688bac061f573a9ad9903d2ce23a
     name: libselinux
     evr: 3.6-3.el9
     sourcerpm: libselinux-3.6-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 203090
     checksum: sha256:e7817e5ab1c6a69683cc020e8e27770eaf8f67b5206726d1a20bfc2fa8bb6b1e
     name: libselinux-utils
     evr: 3.6-3.el9
     sourcerpm: libselinux-3.6-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 136617
     checksum: sha256:fb48b9d444876b4517d441b63955b32ff022b27d99865384900912c55d84f808
     name: libsemanage
     evr: 3.6-5.el9_6
     sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libsepol-3.6-2.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 375368
     checksum: sha256:ca09f44e8158c367d8de245702700ac9a39ada8d7c364bfe8109bd3831c5f0c2
     name: libsepol
     evr: 3.6-2.el9
     sourcerpm: libsepol-3.6-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libsigsegv-2.13-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 31522
     checksum: sha256:9e67d1dd24a8ffa2366479c3c15691b530786ccee77e7c93090c192cce1e63b3
     name: libsigsegv
     evr: 2.13-4.el9
     sourcerpm: libsigsegv-2.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libsmartcols-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 72046
     checksum: sha256:e89669ecb44ca1620f4016d9bc053f00bd174ac9358f22c6a661ae7cee169a79
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libssh-0.10.4-13.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 249438
     checksum: sha256:27243fb5c05797a6b73474132e414e146f3a1b6a06ceb04da6b3292c65e4988c
     name: libssh
     evr: 0.10.4-13.el9
     sourcerpm: libssh-0.10.4-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libssh-config-0.10.4-13.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 11463
     checksum: sha256:0cc66bee3af1b8939f108dce622a47a58482f182ab3abb851b3252a44315aa23
     name: libssh-config
     evr: 0.10.4-13.el9
     sourcerpm: libssh-0.10.4-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 855950
     checksum: sha256:6b60a9d9525edbe9aa461de42844e2beaa7e3a3152d904a5c62cc5eeb129e3af
     name: libstdc++
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 84469
     checksum: sha256:05d77fc16cb5888d298a1d57d419da59894e60eed3220f674f74d50337db167f
     name: libtasn1
     evr: 4.16.0-9.el9
     sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libtool-ltdl-2.4.6-46.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 41941
     checksum: sha256:1aeb1dd5ed52720e71481871150b8feed52d0fed307d38fefb636a2065854107
     name: libtool-ltdl
     evr: 2.4.6-46.el9
     sourcerpm: libtool-2.4.6-46.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libunistring-0.9.10-15.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 519115
     checksum: sha256:8ea5a350f1a29e412100e7b51967f440715f1cf8480a2ccae1a703806953486e
     name: libunistring
     evr: 0.9.10-15.el9
     sourcerpm: libunistring-0.9.10-15.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libutempter-1.2.1-6.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 30656
     checksum: sha256:b62a3c29e31482fc21de315eaefa28f3e52f59396b0a33e6d1267822cabc1c67
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libuuid-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 32345
     checksum: sha256:a53842d536a993fdf027b3e7f465b5c3b00c0fcc7ae297cc8d54757f834d94c4
     name: libuuid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libverto-0.3.2-3.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 25896
     checksum: sha256:54ba79ab0122e9e427efa5b10e9c63dbb28e13c4698711fd5c5bde4e9d794a65
     name: libverto
     evr: 0.3.2-3.el9
     sourcerpm: libverto-0.3.2-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 136063
     checksum: sha256:c0bc93eea8ae33a88c33d7f4ac290a7c4fb844e591fb69a55e50dca8df8fbbff
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libxml2-2.9.13-9.el9_6.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 846422
     checksum: sha256:aa4a2da116bbaba2df4aaed59326584c15f302d48ce7d19c4c53c64af5e9618a
     name: libxml2
     evr: 2.9.13-9.el9_6
     sourcerpm: libxml2-2.9.13-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libzstd-1.5.5-1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 329280
     checksum: sha256:c613b79b53a7d9b00bb33fac7971d412d8f9f9656436cdc8e451e4a805f53ee8
     name: libzstd
     evr: 1.5.5-1.el9
     sourcerpm: zstd-1.5.5-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 152736
     checksum: sha256:5c301c0b57c154457144d7857dcedd4f37025129a9fe868a1c76c9b0461e8e07
     name: lua-libs
     evr: 5.4.4-4.el9
     sourcerpm: lua-5.4.4-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 90452
     checksum: sha256:2a7ef3bd2571c62bf75f3bc1a9206f5715ddcb1cb77f561689de458a417e5914
     name: lz4-libs
     evr: 1.9.3-5.el9
     sourcerpm: lz4-1.9.3-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/m/make-4.3-8.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 567121
     checksum: sha256:6c3f559c10b0bfdeb892314c26622f06999b202f57d881444cc4361ec7dad88c
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/m/mpfr-4.1.0-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 331631
     checksum: sha256:2b26e39f0eb248620c4ad20dff1690502c1912374b8ca7158d6d7eab33c27209
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 426698
     checksum: sha256:be4eaab2dd903908067d3e54f0253a8598b9734ce43e6357dc51fb7cb0d14f21
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/n/ncurses-base-6.2-10.20210508.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 101737
     checksum: sha256:68a97f7bec435800cdbaf8a0c84abb267c4106a97898daed48ce2f931b0f1230
     name: ncurses-base
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/n/ncurses-libs-6.2-10.20210508.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 383309
     checksum: sha256:e0470d7572678bef016f21ad4feb9acbfb579ae6cb1a8ae9eeb9ef3e3b998401
     name: ncurses-libs
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openldap-2.6.8-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 329998
     checksum: sha256:8476e903e6a0ba08961f26a776bd5ae130771ce83edcbc9c57260a49e654c053
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssh-8.7p1-45.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 487150
     checksum: sha256:eb10234c2205c71a0faaa5d26c01d89f67a006993d3f0514ea8f0e380cec263a
     name: openssh
     evr: 8.7p1-45.el9
     sourcerpm: openssh-8.7p1-45.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 760795
     checksum: sha256:2ccc6cf89b038d32c7117903bcc1e5b4040b9cca4ad755f5b0a225efb4f2417f
     name: openssh-clients
     evr: 8.7p1-45.el9
     sourcerpm: openssh-8.7p1-45.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1422952
     checksum: sha256:56283cbf84234ec9256fb68e2d2669bc5799862eb2ee40521b8ac59044567835
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 9614
     checksum: sha256:b73a8baa5f9ad63a9e5afa6c5b3d21c2a9c5d783f129350abb2b234bcf24f17d
     name: openssl-fips-provider
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-6.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 577805
     checksum: sha256:1b4d38df810d7d307ddd529b423edd806fb3832c6a547a065cbf6a9d92987d26
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 2320865
     checksum: sha256:8e9f1ff32873b3531cd38d9583fe20526c790066785312301ea87ebbf980d8ce
     name: openssl-libs
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 547598
     checksum: sha256:fd4240aac85927fc57c6cc5bc689149b3bf1b92b676064bfb23a6107a343310c
     name: p11-kit
     evr: 0.25.3-3.el9_5
     sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/p11-kit-trust-0.25.3-3.el9_5.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 161121
     checksum: sha256:b42303b7d5d10b6303e8abaccbaa302df0bca5fdd9949e043aaf1c5b2a53254d
     name: p11-kit-trust
     evr: 0.25.3-3.el9_5
     sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pam-1.5.1-23.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 686519
     checksum: sha256:4af67a0a6f58135ed562682c60146cdd9be61d7f5e35d83dbe9f3d48c936ce75
     name: pam
     evr: 1.5.1-23.el9
     sourcerpm: pam-1.5.1-23.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pcre-8.44-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 208333
     checksum: sha256:a9194f82f80f11599236c3acd4cd6faf0a4fd4aec302f44365847e6222499e65
     name: pcre
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pcre2-10.40-6.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 243057
     checksum: sha256:fcccf3d6981333ac0ac747ee143dae975381e02025ad2bc53e6aa7e0dc5fafb7
     name: pcre2
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 147926
     checksum: sha256:d386b5e9b3a4b077b2ba143882e605750855dd3354f13c55fa12ed26908cb442
     name: pcre2-syntax
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 46315
     checksum: sha256:a70516a3a8f016a80613bc071586cd653db12a650c4c9f057743125cb7ad7433
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 12416
     checksum: sha256:1d641be62db76b074f4ca2d6b470d85dcf806d96e2c834337482a73984db1979
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 253170
     checksum: sha256:a6fe4abb1aa92ea761b046298129ad6f38693675115794e028204b94443883a3
     name: policycoreutils
     evr: 3.6-2.1.el9
     sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/popt-1.18-8.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 74761
     checksum: sha256:f306d3dc7ae527041162c2f44e153dcd00826c8f79ef588437883c34abe12d9d
     name: popt
     evr: 1.18-8.el9
     sourcerpm: popt-1.18-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 60882
     checksum: sha256:e6ec3390a736b085f403168c512a6b2b6f8e12a8fd5a4459f1c7dbbff2b67c33
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/readline-8.1-4.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 236301
     checksum: sha256:e346c16a0e4b617897f744fe448701cdc90202aecc61d5a40b9ed0986609cb25
     name: readline
     evr: 8.1-4.el9
     sourcerpm: readline-8.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/redhat-release-9.6-0.1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 45208
     checksum: sha256:1f63183436cf44c469e0a14c5664ab1a050e570f9435dd5fd7481d214bb3d2a9
     name: redhat-release
     evr: 9.6-0.1.el9
     sourcerpm: redhat-release-9.6-0.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/redhat-release-eula-9.6-0.1.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 12464
     checksum: sha256:478b4031f4733b7d108f934cb34a652c85a431bc8d5db5c69fc4f27338c45cdd
     name: redhat-release-eula
     evr: 9.6-0.1.el9
     sourcerpm: redhat-release-9.6-0.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/rpm-4.16.1.3-37.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 550411
     checksum: sha256:01ae911787da94e2a895bf34f10bdc13e01c6ce40da9333f25e664ffcc281e7a
     name: rpm
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/rpm-libs-4.16.1.3-37.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 361533
     checksum: sha256:2f7a0732ca6ed52909216b18279bc73a6ae7e6f390cc917234fc5324de68ffe4
     name: rpm-libs
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-37.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 18141
     checksum: sha256:061e49660e069a3b8650edffac05fb0cf2a2e0877a8a0458c502a1418b225af4
     name: rpm-plugin-selinux
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/sed-4.8-9.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 322393
     checksum: sha256:afa65fcc13e68755b67a318737603ed72f9569669c51b858f3c04e99a9272c89
     name: sed
     evr: 4.8-9.el9
     sourcerpm: sed-4.8-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/selinux-policy-38.1.53-5.el9_6.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 46473
     checksum: sha256:e397424c237fb3b0b19f7ba7b1d59ec5a54e8c184ae8be1b1d12223f5ec1f3b7
     name: selinux-policy
     evr: 38.1.53-5.el9_6
     sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/selinux-policy-targeted-38.1.53-5.el9_6.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 7251875
     checksum: sha256:e5a1a2e4ca35e6639ac12a651c3fcb4aede1b62755d71920c9819c7939430b5b
     name: selinux-policy-targeted
     evr: 38.1.53-5.el9_6
     sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 153791
     checksum: sha256:0891d395ce067121c28932534237ad1ce231f2bfa987411ad62e73a12d11eb6a
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/shadow-utils-4.9-12.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 1280653
     checksum: sha256:6b099176192c9819712667442ef8f7123d6f7a4218ed8761312d85052145baa7
     name: shadow-utils
     evr: 2:4.9-12.el9
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/sqlite-libs-3.34.1-7.el9_3.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 724446
     checksum: sha256:d8a7ebd51c41f5db17bff27b830e17e37ccebf154f712e7895765fd2b5a2c454
     name: sqlite-libs
     evr: 3.34.1-7.el9_3
     sourcerpm: sqlite-3.34.1-7.el9_3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/systemd-252-51.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 4457083
     checksum: sha256:cad8a06de0f05f6e55f76f1500c860fcbf692cb11fa56009f464a1508205f121
     name: systemd
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/systemd-libs-252-51.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 732810
     checksum: sha256:86f68a9fa30f82a2cb1dac971d9a9834cfdcb417f0777507e9df8ab7342c4471
     name: systemd-libs
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/systemd-pam-252-51.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 312180
     checksum: sha256:8f6b536625169672d4e0c4469de4bafff1121e6a9548d396341c91876477975b
     name: systemd-pam
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 77716
     checksum: sha256:3cbe727507a7bc53773cd360372d7be3876f8ddf29b0181158c7f250caa3331c
     name: systemd-rpm-macros
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/t/tar-1.34-7.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 937724
     checksum: sha256:f2cc206dfacc9981fad6cf33600ad28bcd1c573f16d8c18523dc9df52ca90660
     name: tar
     evr: 2:1.34-7.el9
     sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 862160
     checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
     name: tzdata
     evr: 2025b-1.el9
     sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/u/util-linux-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 2428895
     checksum: sha256:768413a8cb1df625f0f092355493ddf456c3a491a107108cc165ad44695071cf
     name: util-linux
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 499376
     checksum: sha256:14407b96054d10be6e5b6a7c8d167283caa6b821113bbc6872c4c90fd7da6b1f
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 120233
     checksum: sha256:4e67d1701dc3e5f23191fcbc72e01d48e3287dc32046db9514eb19b902dfc089
     name: xz-libs
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/z/zlib-1.2.11-40.el9.ppc64le.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 106130
     checksum: sha256:330a6c1a9e15d4118a4dbff5b5446f054e42a8286fbd85a416b8d30771d6db6f
     name: zlib
@@ -1560,847 +1560,847 @@ arches:
     sourcerpm: zlib-1.2.11-40.el9.src.rpm
   source:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/c/container-selinux-2.235.0-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 51091
     checksum: sha256:f50793ce3b42d12a5d1429fe9339f656a94df997e3ee27a1416a699138f40e61
     name: container-selinux
     evr: 4:2.235.0-2.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/d/delve-1.24.1-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 9616554
     checksum: sha256:1e062bf60083836bff9b92184c87d2c15034512f45631ffdb1121c31b2b54ddd
     name: delve
     evr: 1.24.1-2.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/e/emacs-27.2-13.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 44822802
     checksum: sha256:dc07aebe8297800966894a228009968015a0787b0dfff5e24ed4406633ebca87
     name: emacs
     evr: 1:27.2-13.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/g/git-2.47.1-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 7707665
     checksum: sha256:dba141092f9144df6e689e08af718722aee96351a7d767175e6dd99fac392264
     name: git
     evr: 2.47.1-2.el9_6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/g/golang-1.23.6-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
-    size: 30652040
-    checksum: sha256:5bccd821e18fd419342d7d5bf2f75f7e28667b46027a6c8c2b8eaf264d6b8142
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/g/golang-1.23.9-1.el9_6.src.rpm
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
+    size: 30660935
+    checksum: sha256:39ac8d05c8b29f959986380fd301c6ff9f548d377d7ecfa28dcf36ae3fa55d6f
     name: golang
-    evr: 1.23.6-2.el9_6
+    evr: 1.23.9-1.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 12784744
     checksum: sha256:f1bf16242337d7910e8a00b94f047a5ae9fc648040321043857318d7ff7132be
     name: perl
     evr: 4:5.32.1-481.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 37030
     checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
     name: perl-Carp
     evr: 1.50-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 131573
     checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
     name: perl-Data-Dumper
     evr: 2.174-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 22653
     checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
     name: perl-Digest
     evr: 1.19-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 60213
     checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
     name: perl-Digest-MD5
     evr: 2.58-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 1915541
     checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
     name: perl-Encode
     evr: 4:3.08-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 46570
     checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
     name: perl-Error
     evr: 1:0.17029-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 32709
     checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
     name: perl-Exporter
     evr: 5.74-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 43503
     checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
     name: perl-File-Path
     evr: 2.18-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 89500
     checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 55697
     checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 93389
     checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 58169
     checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 295384
     checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 43653
     checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
     name: perl-MIME-Base64
     evr: 3.16-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 151174
     checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 693539
     checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 141038
     checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
     name: perl-PathTools
     evr: 3.78-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 22192
     checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 225409
     checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 318605
     checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 91508
     checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 187594
     checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 57721
     checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
     name: perl-Socket
     evr: 4:2.031-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 225886
     checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
     name: perl-Storable
     evr: 1:3.21-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 69123
     checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 23367
     checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
     name: perl-Term-Cap
     evr: 1.17-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 98184
     checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
     name: perl-TermReadKey
     evr: 2.38-11.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 18773
     checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 30727
     checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 54755
     checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
     name: perl-Time-Local
     evr: 2:1.300-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 123780
     checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
     name: perl-URI
     evr: 5.09-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 32045
     checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
     name: perl-constant
     evr: 1.33-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 110461
     checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
     name: perl-libnet
     evr: 3.13-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 23463
     checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
     name: perl-parent
     evr: 1:0.238-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 150048
     checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
     name: perl-podlators
     evr: 1:4.14-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 535332
     checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
     name: acl
     evr: 2.3.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 482234
     checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
     name: attr
     evr: 2.5.1-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1262288
     checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
     name: audit
     evr: 3.1.5-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 9884
     checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
     name: basesystem
     evr: 11-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 10512850
     checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
     name: bash
     evr: 5.1.8-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 22426920
     checksum: sha256:7e8e6c0116f7e862225990df4faaa664fe3b86198538cd350f01b3e5bd16cf41
     name: binutils
     evr: 2.35.2-63.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 498766
     checksum: sha256:0c54d337221bca2bfeafaa7ce372aed7a2fcdb1f800be609ed8579bc1187bcd4
     name: brotli
     evr: 1.0.9-7.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 824335
     checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
     name: bzip2
     evr: 1.0.8-10.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 692817
     checksum: sha256:5d09821ddc46c205eb97656c88a7a553182882e56bfc55fad760a3b1c973ca05
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-91.4.el9_4
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 214658
     checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
     name: chkconfig
     evr: 1.24-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 5692590
     checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
     name: coreutils
     evr: 8.32-39.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 6414228
     checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
     name: cracklib
     evr: 2.9.6-27.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 102787
     checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
     name: crypto-policies
     evr: 20250128-1.git5269e22.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2551840
     checksum: sha256:f0bbcabf62bb18a18bbf9029459fa0fba4488f4b14ed114190aa77fa04c1fc9f
     name: curl
     evr: 7.76.1-31.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 4030574
     checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
     name: cyrus-sasl
     evr: 2.1.27-21.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2143916
     checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
     name: dbus
     evr: 1:1.12.20-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 254475
     checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
     name: dbus-broker
     evr: 28-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 7418303
     checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
     name: e2fsprogs
     evr: 1.46.5-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/e/elfutils-0.192-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 11943728
     checksum: sha256:b5a00f4c49b8980167b250ed7f9e18b90162087cac06276a4fb4ce578a1e3d5a
     name: elfutils
     evr: 0.192-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 8369732
     checksum: sha256:736df300c50aad5de613ee8322bedb9522042024a95df9c886089e225bc764f7
     name: expat
     evr: 2.5.0-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 20486
     checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
     name: filesystem
     evr: 3.16-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2010585
     checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
     name: findutils
     evr: 1:4.8.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3190934
     checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
     name: gawk
     evr: 5.1.0-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 81877102
     checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
     name: gcc
     evr: 11.5.0-5.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1130147
     checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
     name: gdbm
     evr: 1:1.23-1.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.14.src.rpm
-    repoid: rhel-for-baseos-source-rpms
-    size: 19817684
-    checksum: sha256:afd2246bd19e857541d0cd006dcad75fe7f06a72e14727ddd706cdb22a5aaaa3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.19.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 19833749
+    checksum: sha256:31103580ae730950f247bd216d727857590c6349a5958ad5c053fdd42824fbaf
     name: glibc
-    evr: 2.34-168.el9_6.14
+    evr: 2.34-168.el9_6.19
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2503825
     checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
     name: gmp
     evr: 1:6.2.0-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1620891
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 4138121
     checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
     name: groff
     evr: 1.22.4-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 856147
     checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
     name: gzip
     evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 341227
     checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
     name: json-c
     evr: 0.14-11.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.18.1.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
-    size: 149273518
-    checksum: sha256:064936ac5cefb82be159f25be1804f5450d09e1f895c2f831a84060309519211
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.22.1.el9_6.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 149293080
+    checksum: sha256:04ae878f1117937f80e560346f556ceb307ca14f39d9dabe549c402480228edb
     name: kernel
-    evr: 5.14.0-570.18.1.el9_6
+    evr: 5.14.0-570.22.1.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 150790
     checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
     name: keyutils
     evr: 1.6.3-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 582431
     checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
     name: kmod
     evr: 28-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/k/krb5-1.21.1-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 8929002
     checksum: sha256:bbcf124c1665c99bde00f0e2e7faee6ef1efb88dd49f2a9adf8aaf019bf5124f
     name: krb5
     evr: 1.21.1-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 385311
     checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
     name: less
     evr: 590-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 7049522
     checksum: sha256:9d7c7ddde6a8bfe92e4bbdb5e63c25419cb2e997047097ac8fbc7e7c4a3fbd91
     name: libarchive
     evr: 3.5.3-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 202341
     checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
     name: libcap
     evr: 2.48-9.el9_2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 470599
     checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
     name: libcap-ng
     evr: 0.8.2-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 276760
     checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
     name: libcbor
     evr: 0.7.0-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libdb-5.3.28-55.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 35290654
     checksum: sha256:28c77966dc7ce27e5c6e6a1e069d97dcc25529ab0b902f2d0816fd06879ade43
     name: libdb
     evr: 5.3.28-55.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 201501
     checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
     name: libeconf
     evr: 0.4.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 531597
     checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
     name: libedit
     evr: 3.1-38.20210216cvs.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1123179
     checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
     name: libevent
     evr: 2.1.12-8.el9_4
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1367398
     checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
     name: libffi
     evr: 3.4.2-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 865138
     checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
     name: libfido2
     evr: 1.13.0-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3981814
     checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
     name: libgcrypt
     evr: 1.10.0-11.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 994101
     checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
     name: libgpg-error
     evr: 1.42-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2214169
     checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
     name: libidn2
     evr: 2.3.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 9160109
     checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
     name: libpsl
     evr: 0.21.1-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 447225
     checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
     name: libpwquality
     evr: 1.4.4-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/librtas-2.0.6-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 162965
     checksum: sha256:b87597d7d10c2031ef18cb2bbaf2a318ecd21c274855c49d57a9557df3292113
     name: librtas
     evr: 2.0.6-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 653169
     checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
     name: libseccomp
     evr: 2.5.2-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 271153
     checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
     name: libselinux
     evr: 3.6-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 223978
     checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
     name: libsemanage
     evr: 3.6-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 538074
     checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
     name: libsepol
     evr: 3.6-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 473267
     checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
     name: libsigsegv
     evr: 2.13-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libssh-0.10.4-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 670226
     checksum: sha256:27606f3c6b33c346dec927f99a56cece41b09a0780b8c3d33599bb9020a5906f
     name: libssh
     evr: 0.10.4-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1895591
     checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
     name: libtasn1
     evr: 4.16.0-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1002417
     checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
     name: libtool
     evr: 2.4.6-46.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2065802
     checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
     name: libunistring
     evr: 0.9.10-15.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 30093
     checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
     name: libutempter
     evr: 1.2.1-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 396005
     checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
     name: libverto
     evr: 0.3.2-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-9.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3279461
     checksum: sha256:2546fa0329554520374ba2095e925f5647e0c9b22bb2ea242ccbbe025183c5c5
     name: libxml2
     evr: 2.9.13-9.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 521629
     checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
     name: lua
     evr: 5.4.4-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 333421
     checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
     name: lz4
     evr: 1.9.3-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1556195
     checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
     name: mpfr
     evr: 4.1.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3587693
     checksum: sha256:0aa2d8068439cb17c73b678a8c9290e3e9aef0011b7aaa9fa5b24739297b22e4
     name: ncurses
     evr: 6.2-10.20210508.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3998164
     checksum: sha256:6ae71ec17624d7e1e0565a6dc4cff9cb7b88b5bf412d37744703f5a3b5a8a00b
     name: nghttp2
     evr: 1.43.0-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 6548889
     checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
     name: openldap
     evr: 2.6.8-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2415807
     checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
     name: openssh
     evr: 8.7p1-45.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 17985138
     checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 89980613
     checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
     name: openssl-fips-provider
     evr: 3.0.7-6.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1027881
     checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
     name: p11-kit
     evr: 0.25.3-3.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/pam-1.5.1-23.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1116237
     checksum: sha256:6f1b61c1038266830d09be523ff9a25b8a133e6253efaac6ddc0e17479fcedbc
     name: pam
     evr: 1.5.1-23.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1624356
     checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
     name: pcre
     evr: 8.44-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1789790
     checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
     name: pcre2
     evr: 10.40-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf
     evr: 1.7.3-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/policycoreutils-3.6-2.1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 7982064
     checksum: sha256:3ee0c11e4cb602eb81993a8492688246c3d750bc0f592ba895dbce0aa734580a
     name: policycoreutils
     evr: 3.6-2.1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 595630
     checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
     name: popt
     evr: 1.18-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 93646
     checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
     name: publicsuffix-list
     evr: 20210518-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 3009702
     checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
     name: readline
     evr: 8.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 62469
     checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
     name: redhat-release
     evr: 9.6-0.1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 4490587
     checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
     name: rpm
     evr: 4.16.1.3-37.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1424192
     checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
     name: sed
     evr: 4.8-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/selinux-policy-38.1.53-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1165990
     checksum: sha256:d2d67cbefde4402aaf8d4ea0e0820683f183d388c43c3bc7841beefceca1af68
     name: selinux-policy
     evr: 38.1.53-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 195940
     checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
     name: setup
     evr: 2.13.7-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1715281
     checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
     name: shadow-utils
     evr: 2:4.9-12.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-7.el9_3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 25111350
     checksum: sha256:fec74797bb608a73391edf63dd9d4828664ccd8254485f91de39c4b5583d8cb6
     name: sqlite
     evr: 3.34.1-7.el9_3
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/s/systemd-252-51.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 43223467
     checksum: sha256:fd06bfa3f3ee8b7d0f563715a2362c9220bacd78b7ae099690e7439999c5eb05
     name: systemd
     evr: 252-51.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2261512
     checksum: sha256:d002c400d29e7305fe8a982ab6b9f49ee7a8780e4574b86fc0c5b3d5510ecb22
     name: tar
     evr: 2:1.34-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 904607
     checksum: sha256:a2668d1f6b053545a5824a428755484895d72475a9d3833cbfbec9e08660aba2
     name: tzdata
     evr: 2025b-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 6281028
     checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
     name: util-linux
     evr: 2.37.4-21.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1168293
     checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
     name: xz
     evr: 5.2.5-8.el9_0
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 561153
     checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
     name: zlib
     evr: 1.2.11-40.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2378112
     checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
     name: zstd
@@ -2409,1533 +2409,1533 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/container-selinux-2.235.0-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66501
     checksum: sha256:0f6744a8994f03a54b437bc601d4bf734992b78ebc428a9907c330f0e246903e
     name: container-selinux
     evr: 4:2.235.0-2.el9_6
     sourcerpm: container-selinux-2.235.0-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 11229073
     checksum: sha256:b5567c690d46d4f5a2cb13be6a4f962dbe8cc7e821b9d3baa09a4f10c59014d9
     name: cpp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/delve-1.24.1-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 5564503
     checksum: sha256:cc66f6922ec43fb3ca4bfdadd0ba9c8724f8a910763e4e6ca82d31db16ed8ae4
     name: delve
     evr: 1.24.1-2.el9_6
     sourcerpm: delve-1.24.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-13.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9758
     checksum: sha256:624b6683efb3e254eb8f44a927772ec251a841803b7f693f9c6ad0651e694557
     name: emacs-filesystem
     evr: 1:27.2-13.el9_6
     sourcerpm: emacs-27.2-13.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 216340
     checksum: sha256:c1fcc71c1cc1160d58ace4b60cc6733b68d6f6d406e5ec5ce24327787f452cd1
     name: gawk-all-langpacks
     evr: 5.1.0-6.el9
     sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34006000
     checksum: sha256:03c99bc1021dbe54dd93120ed6b5249bbb02dbd5da9e0dc5d8c4a21d674fb1fd
     name: gcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/git-2.47.1-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 55489
     checksum: sha256:35c844a31e6877ad10dcd4c695f3f159ab88dc6978bc98b45b8ee47e94b5536b
     name: git
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/git-core-2.47.1-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 4947862
     checksum: sha256:ae898605cf906ea73181921224143895e20a6eca5df56e8b092bc78e634cb09f
     name: git-core
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/git-core-doc-2.47.1-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 3194257
     checksum: sha256:172dd65142fcd6548658a47e46d06a9a80251ab7a2cd6da6a0a99bb92e83cb56
     name: git-core-doc
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 35566
-    checksum: sha256:1565ca914cb58037fc9f50af64be3a43d5ae854b5d30f01882eb06d57c44d52c
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 35292
+    checksum: sha256:af4689df30283c54a741414934d8955cb951ff7dace9d0b4b2715631a299d7d1
     name: glibc-devel
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 554474
-    checksum: sha256:10579e7e1a0140841209c023fdb9034aae1b3723ab5807f6e6c61e8dd2dbffa7
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 554238
+    checksum: sha256:a6772c8a603f5322b126bcd287932fccde7edf392ced7de2632bafbd43d1549e
     name: glibc-headers
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/go-toolset-1.23.6-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 11361
-    checksum: sha256:6221f1050acdbe50d46426e8d04e9f64c69fdea36c843c464792a8200f183ee0
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/go-toolset-1.23.9-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 6949
+    checksum: sha256:f2318169dc27a8ab88b00124af3c0071cd9bf7a4772bebfebfc823fe10d01e90
     name: go-toolset
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-1.23.6-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 700365
-    checksum: sha256:3f868f055d64ba4450eddd5bf8aed497990454fb4f314e2d0fb4a0b22ff5bab2
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-1.23.9-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 695932
+    checksum: sha256:e9569c26447d0276ed0c75ab928f38f15f4cb1f20f76929aa24d24e2c59064eb
     name: golang
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-bin-1.23.6-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 66152222
-    checksum: sha256:0c28b320d792c2984006eae41792a47bc827a875607fd16ed0604397d549812e
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-bin-1.23.9-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 66194853
+    checksum: sha256:9295f72d811825bb150bb2e750d06421bf42a5f7ff1113d8359dff28fe64deec
     name: golang-bin
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-race-1.23.6-2.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 210598
-    checksum: sha256:8112bfa5292cfbe4f670b689aba65e8d7a0a9985d0f8845bde1313849f4d6aad
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-race-1.23.9-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 209871
+    checksum: sha256:955d95833d8f126ca4ef19079d6b0eb463532af2754a2ae7b6febc8a78ffed3e
     name: golang-race
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-src-1.23.6-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 11302169
-    checksum: sha256:8c5a8b16db661b76afda382c55749692277a3fd7482a4ab4838822e467c7560c
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/golang-src-1.23.9-1.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 11297588
+    checksum: sha256:3712d0ba4ede1c0aa2e7cfd4384cbb7378de4cbd355a1ad91b1dcdfbc3bdd03e
     name: golang-src
-    evr: 1.23.6-2.el9_6
-    sourcerpm: golang-1.23.6-2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.18.1.el9_6.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
-    size: 3681841
-    checksum: sha256:67dd8cdd0ad69f0fff631da9cbd14c3de0a92d1c1f42c9bd65b0ae9cc2659f7a
+    evr: 1.23.9-1.el9_6
+    sourcerpm: golang-1.23.9-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.22.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 3685565
+    checksum: sha256:d25bdcc8e855c3bb18210fc4207cdd19a095421abced48c446a69238963d6d34
     name: kernel-headers
-    evr: 5.14.0-570.18.1.el9_6
-    sourcerpm: kernel-5.14.0-570.18.1.el9_6.src.rpm
+    evr: 5.14.0-570.22.1.el9_6
+    sourcerpm: kernel-5.14.0-570.22.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66075
     checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 33101
     checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 4650823
     checksum: sha256:30cd1b3dec089a7da71e9167532693bef7c202a5dbe3c010af2a9387106a0b36
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-B-1.80-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 188182
     checksum: sha256:1d9743f0a5ba875908984dbe875025aa51bc62fc9d1bec3fbef12f6688c1d771
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 59910
     checksum: sha256:6cd912e640cbc8785e33dae9cf07561509491a0ec76a81c01d6b7a77ad08668d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 40274
     checksum: sha256:2a6b21a144ae1d060e51ee2b6328c5dd1a646f429da160f386c2eb420b1220b4
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 26423
     checksum: sha256:f238e85f5fe854109793f966e7e36f14165979aee78fc2de39037b9f69ca3178
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1802386
     checksum: sha256:d05248697e48928be004ed4c683b04966aa452ae1e2bd81f650c6de108b46956
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15331
     checksum: sha256:891006d2a5ec8528b1e7fe181a3e1617733b1050250b381f29261b70e83865ed
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22098
     checksum: sha256:726645728dabb2f1badb1c4a6170c5db29118a536cdfa482c882aaef6ed97fb4
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Git-2.47.1-2.el9_6.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 40089
     checksum: sha256:3bb2b9b3f197bb548455a5ed7304ef25510f4ae6f4ee92dd4db74946a869442e
     name: perl-Git
     evr: 2.47.1-2.el9_6
     sourcerpm: git-2.47.1-2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94663
     checksum: sha256:dc85c28902667c1bd3c6f19b6a08bdda5e1d25b11e832b269e15fde94e6ab52d
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35058
     checksum: sha256:3ae8affe13cc15cfaee1c6dd078ada14891dde5dca263927a9b5ed87f241d2c0
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 23899
     checksum: sha256:fbd179e177943079b17db7c887b77dcca46b009ae41d85da5c16e1f33d20a1c9
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 428188
     checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 100044
     checksum: sha256:70b078b5b692c8d8b26600ae4868b50d613289a89c50b702109bce542d2c8888
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94564
     checksum: sha256:0647785b169c4bbdc65adf06d28981ce7fd1c9f93aecaa4e53a4515a21ebbf81
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 77262
     checksum: sha256:7ce874bde7d9ad15abf70a3b7edbab77548eb2eb8b529c1e48b2426ee7f948f9
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 59776
     checksum: sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 100335
     checksum: sha256:0097fdb40a1f83e56d5bf91160c07151b7cdd64f829fc0e328cdf3b43c2b4fa6
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 41023
     checksum: sha256:5ff266e740a93344e1ce2913f4bec0f38cfdf721841e6762d85ac21d716ee9f8
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 74840
     checksum: sha256:359a94a09f0082a637c5bc2aa4ddac23dd79e929daa38dfed85d0e1afff31fba
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-lib-0.65-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15318
     checksum: sha256:89bf58fb4d09ec404ea98063d4a7099ff00b59e9a9e0bb04067f48e3fb581083
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2303445
     checksum: sha256:d20aebf4d96f4ad0e7dc97b63bbe41baa6f927a34eac9068a22f1d62e71611dc
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.el9.x86_64.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30125
     checksum: sha256:3cf76960b8c866deebf333a9dfd64a7dd9f4689cb82e37d0c0ddab2c031b3651
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
-    repoid: rhel-for-appstream-rpms
+    repoid: rhel-9-for-x86_64-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 77226
     checksum: sha256:150d7232faa90f84a09268f8998ee32670eef59cba98612aeb996ab75c4dfcc4
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/a/alternatives-1.24-2.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42874
     checksum: sha256:1c520b9bf7b592d936bb347a5107702e51678e160b88ecfbba6a30e35e47d24e
     name: alternatives
     evr: 1.24-2.el9
     sourcerpm: chkconfig-1.24-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/a/audit-libs-3.1.5-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 127977
     checksum: sha256:ab86c7bd1a87a0f613e99af5c6d2e7da662fc1e9bd826ec68384b1115f09fe31
     name: audit-libs
     evr: 3.1.5-4.el9
     sourcerpm: audit-3.1.5-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/basesystem-11-13.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 8229
     checksum: sha256:f498b0813fa1a825d550e8e3a9e42255eabfa18e6fc96adfc6cc8fa7e16dd513
     name: basesystem
     evr: 11-13.el9
     sourcerpm: basesystem-11-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/bash-5.1.8-9.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1769540
     checksum: sha256:d3adf8b09aa0bf935c67aa12444e0ee02f70a82c2682bfb2b02bda0a989bb806
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4818636
     checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
     name: binutils
     evr: 2.35.2-63.el9
     sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 753176
     checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
     name: binutils-gold
     evr: 2.35.2-63.el9
     sourcerpm: binutils-2.35.2-63.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/bzip2-libs-1.0.8-10.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42618
     checksum: sha256:5058aca2a4c5ac3356fb42e6e423e4101bc29199e0ae80d79d3fc564ba9d7c84
     name: bzip2-libs
     evr: 1.0.8-10.el9_5
     sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1044629
     checksum: sha256:fda07ba8aa8afd38800aa1e49ddd4c7916d8f67030739f85f59727f47bdf28dd
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-91.4.el9_4
     sourcerpm: ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/coreutils-8.32-39.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1245548
     checksum: sha256:091268f0d2e4afb6fe29b0536c67410af2c08147ecb316a12492b6f4eb84c835
     name: coreutils
     evr: 8.32-39.el9
     sourcerpm: coreutils-8.32-39.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/coreutils-common-8.32-39.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2113564
     checksum: sha256:da1d14b6ad93241b26e38bc3d5187028e2eeda71867931ccc9ab150d88df8393
     name: coreutils-common
     evr: 8.32-39.el9
     sourcerpm: coreutils-8.32-39.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 100903
     checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 3821230
     checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/crypto-policies-20250128-1.git5269e22.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 92144
     checksum: sha256:e3ca18b4805fe8624d7d884859c167c14f48a4a1565b75403bb7470e7132cc1a
     name: crypto-policies
     evr: 20250128-1.git5269e22.el9
     sourcerpm: crypto-policies-20250128-1.git5269e22.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-31.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 304406
     checksum: sha256:a5a9185a6295ef7880a50d58fcc8fb83392fbc52dc1406175091e87cf193097c
     name: curl
     evr: 7.76.1-31.el9
     sourcerpm: curl-7.76.1-31.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-lib-2.1.27-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 792070
     checksum: sha256:d92f2383e68062b9ded78afa8814f18d84fee98e09781f541169627272ce85cf
     name: cyrus-sasl-lib
     evr: 2.1.27-21.el9
     sourcerpm: cyrus-sasl-2.1.27-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 8073
     checksum: sha256:96b1daa4de0a635ab760a8431fb005022bb7cb48d2d1d3ec9a8adb1798c0e10e
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 179634
     checksum: sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 411559
     checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 47282
     checksum: sha256:e5b1a7a9e1467bfe00913e9b22ba5665852f8c61900205a32d3043ace9e1c7c2
     name: elfutils-debuginfod-client
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.192-5.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9839
     checksum: sha256:fb2fe6a8f7552aecda6c998adddb0f88264252b6f717a306adfd0c24b0e33e79
     name: elfutils-default-yama-scope
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.192-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 212505
     checksum: sha256:20ef8ae38ec86e43d0adc5b8473bb8feeb880467dfda93f37f0d362ba06a79bc
     name: elfutils-libelf
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.192-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 270058
     checksum: sha256:a72237e0bffd7ae464d4c0eb7707947a611dc96a667409c7c4a0e73e75cc4ebc
     name: elfutils-libs
     evr: 0.192-5.el9
     sourcerpm: elfutils-0.192-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 121835
     checksum: sha256:63522da84934e944305c9e206894031988ab9e561bba2e6c131d76093d1a0211
     name: expat
     evr: 2.5.0-5.el9_6
     sourcerpm: expat-2.5.0-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/filesystem-3.16-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 5003807
     checksum: sha256:9567592e6e32a9ebd45584cc4feb5d00812f143fcb2d8cd8b1d95108f4f66a2d
     name: filesystem
     evr: 3.16-5.el9
     sourcerpm: filesystem-3.16-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 563531
     checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
     name: findutils
     evr: 1:4.8.0-7.el9
     sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gawk-5.1.0-6.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1045534
     checksum: sha256:99fda6725a2c668bae29fbab74d1b347e074f4e8c8ed18d656cb928fb6fc92b7
     name: gawk
     evr: 5.1.0-6.el9
     sourcerpm: gawk-5.1.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gdbm-libs-1.23-1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 60152
     checksum: sha256:c8b8346a98d921206666ce740a3647a52ad7a87c2d01d73166165b3e9a789a6c
     name: gdbm-libs
     evr: 1:1.23-1.el9
     sourcerpm: gdbm-1.23-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 2054217
-    checksum: sha256:de8eb45949d4471b59305346c1b55c156fcb0c2b82dab524aa09bef1a0307e69
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 2053633
+    checksum: sha256:4037b95b7736a8ffd5c45327961fa1d76f7b81603b0409308a0d267329a3ec3d
     name: glibc
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 311029
-    checksum: sha256:df87055efc323b9d82297ca62d1e9c5b23dde42feae85bb568f583ed93bdfe19
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 310722
+    checksum: sha256:944abf13ff74e185182ed3831c9cea059d40c365b2d901757640afaa810a71d8
     name: glibc-common
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 1753645
-    checksum: sha256:df6ded7d6c44fb4b23e9d11cf63b8b81f12f1edc08f5a19f20c1c059d3cf8649
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1754220
+    checksum: sha256:58655a175ca0441113749257ac099d6e5ed6097469ad3c5e6df530bc504570b4
     name: glibc-gconv-extra
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-168.el9_6.14.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
-    size: 19997
-    checksum: sha256:e33e3151973289f4cdccf2ec13ebe63325609a60d4502a399707545866917d2c
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-168.el9_6.19.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 19725
+    checksum: sha256:d2020520c34502da293ceec484a9fada3db81fe462bdb0081e1e412fccc873ab
     name: glibc-minimal-langpack
-    evr: 2.34-168.el9_6.14
-    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+    evr: 2.34-168.el9_6.19
+    sourcerpm: glibc-2.34-168.el9_6.19.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gmp-6.2.0-13.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 326840
     checksum: sha256:d4529445e30b7eb9a8225b0539f70d26d585d7fe306296f948ea73114d1c171f
     name: gmp
     evr: 1:6.2.0-13.el9
     sourcerpm: gmp-6.2.0-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/grep-3.6-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 279174
     checksum: sha256:5556895ff1817066ca71b50785615e944b0fcc7e1c94c983087c7c691819623d
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1133828
     checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 171206
     checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/json-c-0.14-11.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 46136
     checksum: sha256:b9bde4162250023103d95908fbca44fff6636a46176f92cf1761c1c3a4580a2f
     name: json-c
     evr: 0.14-11.el9
     sourcerpm: json-c-0.14-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/keyutils-libs-1.6.3-1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 34363
     checksum: sha256:96d75824948387a884d206865db534cd3d46f32422efcb020c20060b59edb27c
     name: keyutils-libs
     evr: 1.6.3-1.el9
     sourcerpm: keyutils-1.6.3-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-10.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 66607
     checksum: sha256:9ae0b89812908ee50ec654ba35f74dc478057e8981afd4a5cc8d2befd987b342
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/krb5-libs-1.21.1-6.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 788740
     checksum: sha256:7865d4a8f8f2c212e9a42f42b68ed8d6f93c0c83e490accd6651a78f82b165cd
     name: krb5-libs
     evr: 1.21.1-6.el9
     sourcerpm: krb5-1.21.1-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 170758
     checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
     name: less
     evr: 590-5.el9
     sourcerpm: less-590-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libacl-2.3.1-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 24627
     checksum: sha256:dc50fd67447efd6367395b3e1517bfc1fa958652a75ce7619358812a8f6c80aa
     name: libacl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libarchive-3.5.3-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 401302
     checksum: sha256:3adc7a9ace1115daa32a327c9f257fc113c1a3a7e561443189f6318222e30238
     name: libarchive
     evr: 3.5.3-4.el9
     sourcerpm: libarchive-3.5.3-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libattr-2.5.1-3.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 20786
     checksum: sha256:6519f028915fbd7ee0474f0bf4e98e35f04b5d0cf7be9f66c0cb9eafac0b8c5a
     name: libattr
     evr: 2.5.1-3.el9
     sourcerpm: attr-2.5.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libblkid-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 111211
     checksum: sha256:d3cb190d20c5bdf24fff25acb78fd2bb5026efb86b3b8d51c35362c16e7563a1
     name: libblkid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 323932
     checksum: sha256:bb3175e435723e98cc1a5063eafa82231092eca3bf6276d24505eaeaaa817113
     name: libbrotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcap-2.48-9.el9_2.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 76130
     checksum: sha256:d108abf74d0a27a1f82f9fe868db403622b0486e547c4b9557a18d367981fe24
     name: libcap
     evr: 2.48-9.el9_2
     sourcerpm: libcap-2.48-9.el9_2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcap-ng-0.8.2-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 36752
     checksum: sha256:ebddfc188d1ddbb0d6a238583cbc02dcb9fc0bd063a850b22d48980899976628
     name: libcap-ng
     evr: 0.8.2-7.el9
     sourcerpm: libcap-ng-0.8.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 60575
     checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
     name: libcbor
     evr: 0.7.0-5.el9
     sourcerpm: libcbor-0.7.0-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcom_err-1.46.5-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 28588
     checksum: sha256:29a55b3f2af38a5ead96273df2b6a8ce35b99110f81abaecc4be92f77222a272
     name: libcom_err
     evr: 1.46.5-7.el9
     sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcurl-7.76.1-31.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 292648
     checksum: sha256:330279706b226ca5b8257e246131b726a485ebfc6d7ffb0c842e770dbc2ded28
     name: libcurl
     evr: 7.76.1-31.el9
     sourcerpm: curl-7.76.1-31.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-55.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 754739
     checksum: sha256:b019fc2c6ec5d05c7225a189c0e751be4c1c572b82991022809cc8c1f4fa0a89
     name: libdb
     evr: 5.3.28-55.el9
     sourcerpm: libdb-5.3.28-55.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30371
     checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
     name: libeconf
     evr: 0.4.1-4.el9
     sourcerpm: libeconf-0.4.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 109330
     checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libevent-2.1.12-8.el9_4.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 272588
     checksum: sha256:072426910a254b797bbe977b3397ab90513911d020580a0135179f700a48df44
     name: libevent
     evr: 2.1.12-8.el9_4
     sourcerpm: libevent-2.1.12-8.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 159417
     checksum: sha256:81c7676b72b85d8b5822888c510952ec0996b3d89bf8cddaf76dba31bc72a4a1
     name: libfdisk
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libffi-3.4.2-8.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 40619
     checksum: sha256:dde0012a94c6f3825e605b095b15767d89c2b87a5da097348310d7e87721c645
     name: libffi
     evr: 3.4.2-8.el9
     sourcerpm: libffi-3.4.2-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 102746
     checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
     name: libfido2
     evr: 1.13.0-2.el9
     sourcerpm: libfido2-1.13.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgcc-11.5.0-5.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 89621
     checksum: sha256:6f7bc4ed734b01d36f9dba66f34f610f2f39e5280588814a666b4d4be2dd8807
     name: libgcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 522581
     checksum: sha256:9d5a5a4292a5a345143b632c2764ad8e7b095413f78f5693d29c2ea5e7d37119
     name: libgcrypt
     evr: 1.10.0-11.el9
     sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 269396
     checksum: sha256:da7af36960df4b59178f4d7c42353d48c53fbe231e7e62d734a4319748f897a9
     name: libgomp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgpg-error-1.42-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 225603
     checksum: sha256:8248e20d7a253aa9c0dc7dc3d56b42e1def4fd5753ce8e8b9e980aa664fc9068
     name: libgpg-error
     evr: 1.42-5.el9
     sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libidn2-2.3.0-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 107099
     checksum: sha256:055f4ce6b721be7138dc2e45a6586412c65508acea3fe385a2655c129fe264f9
     name: libidn2
     evr: 2.3.0-7.el9
     sourcerpm: libidn2-2.3.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libmount-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 139470
     checksum: sha256:49b2b2a02d276281bc02907b1d5431fd07ac200d47e621a41ca5169d30537442
     name: libmount
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnghttp2-1.43.0-6.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 76742
     checksum: sha256:ebc37f2252164962b03dd3a4b5e53ab5e1e9234a8657219e8c8e9064dcb98b2e
     name: libnghttp2
     evr: 1.43.0-6.el9
     sourcerpm: nghttp2-1.43.0-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38387
     checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 67454
     checksum: sha256:ad1a62ef07682bb64a476c1a49f5cfc7abc9beb44775e7e511bf737e9a6bf99d
     name: libpsl
     evr: 0.21.1-5.el9
     sourcerpm: libpsl-0.21.1-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 126104
     checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 76200
     checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libselinux-3.6-3.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 89722
     checksum: sha256:ce1cc63a7212c39f5f2a35f719ee38d6418cf081ea78c9317f388d9f41e4a627
     name: libselinux
     evr: 3.6-3.el9
     sourcerpm: libselinux-3.6-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 198410
     checksum: sha256:e5d79885864cd5b2a307065b43ba1af1523ec7ac26eace2717c70ede1b6e4c56
     name: libselinux-utils
     evr: 3.6-3.el9
     sourcerpm: libselinux-3.6-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libsemanage-3.6-5.el9_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 123449
     checksum: sha256:7ac29f46714cd762f18a52e9807fd1766b0cf9e0388aa3d9befaabf8785a01e3
     name: libsemanage
     evr: 3.6-5.el9_6
     sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libsepol-3.6-2.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 339134
     checksum: sha256:7bdec83a13ff92144024d44c8179fc083e5581afa710829a9dccd7895233d1f2
     name: libsepol
     evr: 3.6-2.el9
     sourcerpm: libsepol-3.6-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libsigsegv-2.13-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30681
     checksum: sha256:24005c62017797b612d047a2af83a218633b32302a787fabd22e52230db6adc1
     name: libsigsegv
     evr: 2.13-4.el9
     sourcerpm: libsigsegv-2.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libsmartcols-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 66253
     checksum: sha256:bdf30ad7ecb50b5a883fb55b21074b7ae8a8273dfba84f81401d10917bcdac4b
     name: libsmartcols
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-13.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 224804
     checksum: sha256:7c51bc940814b49a57b331b68508732b76b16f5c237538c26fc06e6d824da77f
     name: libssh
     evr: 0.10.4-13.el9
     sourcerpm: libssh-0.10.4-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-13.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 11463
     checksum: sha256:0cc66bee3af1b8939f108dce622a47a58482f182ab3abb851b3252a44315aa23
     name: libssh-config
     evr: 0.10.4-13.el9
     sourcerpm: libssh-0.10.4-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libstdc++-11.5.0-5.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 759582
     checksum: sha256:bd344d5654cc4385fc5480249a873a418bcdee6ba8a257012edc3bc255c63ab0
     name: libstdc++
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libtasn1-4.16.0-9.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 78596
     checksum: sha256:3c619506cf4283d4d30d9e681a3565f79c1009f5e4a47d71b0de78c5ee24c91d
     name: libtasn1
     evr: 4.16.0-9.el9
     sourcerpm: libtasn1-4.16.0-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libtool-ltdl-2.4.6-46.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38043
     checksum: sha256:44f7303229bdb4c2975f9829e3dd13dc7984e2cb53ef0f85baf894b39f605c38
     name: libtool-ltdl
     evr: 2.4.6-46.el9
     sourcerpm: libtool-2.4.6-46.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libunistring-0.9.10-15.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 510558
     checksum: sha256:6477fb3c3285158f676360e228057e13dc6e983f453c7c74ed4ab140357f9a0d
     name: libunistring
     evr: 0.9.10-15.el9
     sourcerpm: libunistring-0.9.10-15.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30354
     checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libuuid-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30462
     checksum: sha256:04d74d33e9582ba723061d06f972118fdb4867d307164f61ea4778f7fa67aed7
     name: libuuid
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libverto-0.3.2-3.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 25042
     checksum: sha256:7008029afd91af33ca17a22e6eb4ba792fd9b32bee8fb613c79c1527fa6f589a
     name: libverto
     evr: 0.3.2-3.el9
     sourcerpm: libverto-0.3.2-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libxcrypt-4.4.18-3.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 122599
     checksum: sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d
     name: libxcrypt
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libxml2-2.9.13-9.el9_6.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 769351
     checksum: sha256:6cb4fe01744a6b1c8a807dca29c2fd37443fcad9e4318fd72588f83d6cdec406
     name: libxml2
     evr: 2.9.13-9.el9_6
     sourcerpm: libxml2-2.9.13-9.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libzstd-1.5.5-1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 304135
     checksum: sha256:d8a149f0d8f217126642cc4b40199d631b940f7d227191cc2179f3158fd47f9e
     name: libzstd
     evr: 1.5.5-1.el9
     sourcerpm: zstd-1.5.5-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lua-libs-5.4.4-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 135403
     checksum: sha256:9c6c7abe93691e0a6be505199cccab5a41f92ada084faa4f1045ce3932b34d05
     name: lua-libs
     evr: 5.4.4-4.el9
     sourcerpm: lua-5.4.4-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lz4-libs-1.9.3-5.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 70922
     checksum: sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731
     name: lz4-libs
     evr: 1.9.3-5.el9
     sourcerpm: lz4-1.9.3-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 553896
     checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/mpfr-4.1.0-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 337166
     checksum: sha256:cf60adcc7a5f0cb469e6f066a1bdc62ae9af7c06305c76c15884b59df7f93274
     name: mpfr
     evr: 4.1.0-7.el9
     sourcerpm: mpfr-4.1.0-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 420158
     checksum: sha256:1b5e5805334bc78c977d7acf02256021a9216e26348a5383cf86dfb0b0c91101
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ncurses-base-6.2-10.20210508.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 101737
     checksum: sha256:68a97f7bec435800cdbaf8a0c84abb267c4106a97898daed48ce2f931b0f1230
     name: ncurses-base
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ncurses-libs-6.2-10.20210508.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 339787
     checksum: sha256:a283044b02b1c640cb280fa6ff4ef340a3156b81f8cf167041c5990d498a6886
     name: ncurses-libs
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openldap-2.6.8-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 296805
     checksum: sha256:68df8cf8fb4d54c2f1681fa9a030f7af3b179e6dd4fd10ffd7532824121ea74c
     name: openldap
     evr: 2.6.8-4.el9
     sourcerpm: openldap-2.6.8-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 474534
     checksum: sha256:d43f19d3e736943bdadbda47db016e9da81ce1900f50ecfe470f7a8bc9bce243
     name: openssh
     evr: 8.7p1-45.el9
     sourcerpm: openssh-8.7p1-45.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 735750
     checksum: sha256:309d1c9c176bf35b494c8b31a0f3eeceddd0b27be1dfc9defbe9838b9d5a707c
     name: openssh-clients
     evr: 8.7p1-45.el9
     sourcerpm: openssh-8.7p1-45.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1420999
     checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 9625
     checksum: sha256:bd9266695b8238ed6fe436ae5f613cee2e5e1ee5d612ab495f1da2f21f2830aa
     name: openssl-fips-provider
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-6.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 590625
     checksum: sha256:451372cea98f4993b2a4a2ed5876f1a661450e7487f73f945bbaf34789931437
     name: openssl-fips-provider-so
     evr: 3.0.7-6.el9_5
     sourcerpm: openssl-fips-provider-3.0.7-6.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2218318
     checksum: sha256:287d11706d44a53455ed8ac62faab4c4a0b8c0fa5e367adf122c7a76c6ddbbb8
     name: openssl-libs
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/p11-kit-0.25.3-3.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 548533
     checksum: sha256:e5a99495f837953c90ae46d0226fec22ae972ff57074b31f9a5a1dd9c562065f
     name: p11-kit
     evr: 0.25.3-3.el9_5
     sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/p11-kit-trust-0.25.3-3.el9_5.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 147809
     checksum: sha256:16a699351e080fceea5b3aec2dc53a290cad960b8c94cf88832107843e452fc2
     name: p11-kit-trust
     evr: 0.25.3-3.el9_5
     sourcerpm: p11-kit-0.25.3-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-23.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 647096
     checksum: sha256:5f261b23e11d27a49e5ddcb83ee93f37834a8160c82a0b82dbe6bf07acdfd96b
     name: pam
     evr: 1.5.1-23.el9
     sourcerpm: pam-1.5.1-23.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pcre-8.44-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 205261
     checksum: sha256:e9ddc7d57d4f6e7400b66bcc78b9bafc1f05630e3e0d2a14000bc907f429ddc4
     name: pcre
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pcre2-10.40-6.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 241900
     checksum: sha256:75db1e5a50e7b1794d7ba18212d95cd2684559da9e7c52eee46490302c7f24dd
     name: pcre2
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pcre2-syntax-10.40-6.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 147926
     checksum: sha256:d386b5e9b3a4b077b2ba143882e605750855dd3354f13c55fa12ed26908cb442
     name: pcre2-syntax
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 45675
     checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 12438
     checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 251967
     checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
     name: policycoreutils
     evr: 3.6-2.1.el9
     sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/popt-1.18-8.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 70397
     checksum: sha256:1649240d2a69e13d3b5ddc5c5e63c5d64a77930578a6bc4c3aca32f00423cd87
     name: popt
     evr: 1.18-8.el9
     sourcerpm: popt-1.18-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 60882
     checksum: sha256:e6ec3390a736b085f403168c512a6b2b6f8e12a8fd5a4459f1c7dbbff2b67c33
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/readline-8.1-4.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 220174
     checksum: sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6
     name: readline
     evr: 8.1-4.el9
     sourcerpm: readline-8.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/redhat-release-9.6-0.1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 45201
     checksum: sha256:398d7315a731a2de704ce0778909319dde39abab328e1259b95fbf8207c8a98c
     name: redhat-release
     evr: 9.6-0.1.el9
     sourcerpm: redhat-release-9.6-0.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/redhat-release-eula-9.6-0.1.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 12477
     checksum: sha256:fa313cd54f7430fc08f149c042826ce060136c26eb0b17799d43d9673a236dcc
     name: redhat-release-eula
     evr: 9.6-0.1.el9
     sourcerpm: redhat-release-9.6-0.1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-4.16.1.3-37.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 553178
     checksum: sha256:82e6029041dde8c460b2332bc3bacd326be0275a1d94a02463c402e0661d28e6
     name: rpm
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-libs-4.16.1.3-37.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 317343
     checksum: sha256:b9f8b399a35af89bf96e0898596d0cdf36912486001d5b05a9482703d8255fee
     name: rpm-libs
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-37.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 18109
     checksum: sha256:1e21fe626bb81ccf59e8de8194395017e3a5fa929cbf6c6da82ba1598f6bb27f
     name: rpm-plugin-selinux
     evr: 4.16.1.3-37.el9
     sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/sed-4.8-9.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 316395
     checksum: sha256:bf3baf444e49eba4189e57d562a7522ab714132d2960db87ef9b99f1b46a3cc4
     name: sed
     evr: 4.8-9.el9
     sourcerpm: sed-4.8-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.53-5.el9_6.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 46473
     checksum: sha256:e397424c237fb3b0b19f7ba7b1d59ec5a54e8c184ae8be1b1d12223f5ec1f3b7
     name: selinux-policy
     evr: 38.1.53-5.el9_6
     sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.53-5.el9_6.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 7251875
     checksum: sha256:e5a1a2e4ca35e6639ac12a651c3fcb4aede1b62755d71920c9819c7939430b5b
     name: selinux-policy-targeted
     evr: 38.1.53-5.el9_6
     sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/setup-2.13.7-10.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 153791
     checksum: sha256:0891d395ce067121c28932534237ad1ce231f2bfa987411ad62e73a12d11eb6a
     name: setup
     evr: 2.13.7-10.el9
     sourcerpm: setup-2.13.7-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/shadow-utils-4.9-12.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1257960
     checksum: sha256:97581b725af384553fa72773ad29e2a5112e3a3ce081ae811d89ff5b75a93b92
     name: shadow-utils
     evr: 2:4.9-12.el9
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/sqlite-libs-3.34.1-7.el9_3.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 636432
     checksum: sha256:bac33c2d93e3902cf92bd98b2ed5111748777cc06832417357158d61cee26d4e
     name: sqlite-libs
     evr: 3.34.1-7.el9_3
     sourcerpm: sqlite-3.34.1-7.el9_3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-252-51.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4425249
     checksum: sha256:7bd22f7b3872de16d5b6dfd95051c7bd7bccecc0e2216093c3f82cf4a96275ce
     name: systemd
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-libs-252-51.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 700435
     checksum: sha256:c14fb5970e2eb386a2291e8bf3a8a10307df47f560dfe35bc9380230e9809231
     name: systemd-libs
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 294725
     checksum: sha256:4bf47b8480375f5972ccd826a8bf51700df22bc2a7767daa81e1d50366e64ea2
     name: systemd-pam
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 77716
     checksum: sha256:3cbe727507a7bc53773cd360372d7be3876f8ddf29b0181158c7f250caa3331c
     name: systemd-rpm-macros
     evr: 252-51.el9
     sourcerpm: systemd-252-51.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 910235
     checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
     name: tar
     evr: 2:1.34-7.el9
     sourcerpm: tar-1.34-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tzdata-2025b-1.el9.noarch.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 862160
     checksum: sha256:0687e5a1115ba679137404c8d37a45141a31968ffd01677455530d24c126a0d2
     name: tzdata
     evr: 2025b-1.el9
     sourcerpm: tzdata-2025b-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2395065
     checksum: sha256:61c795084ae4b7745b904347d4643110cd62558fce2978bd4f025ff83524e55f
     name: util-linux
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 480619
     checksum: sha256:36389814fcec56d9b9d4bd1a4a63efb1cefa00bc8bacab73f89ef8f8be04b1cd
     name: util-linux-core
     evr: 2.37.4-21.el9
     sourcerpm: util-linux-2.37.4-21.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/x/xz-libs-5.2.5-8.el9_0.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 96649
     checksum: sha256:de263f880a4394f04b5e84254ba0a88d781b5bd63665c9e028bc10351490c982
     name: xz-libs
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/z/zlib-1.2.11-40.el9.x86_64.rpm
-    repoid: rhel-for-baseos-rpms
+    repoid: rhel-9-for-x86_64-baseos-rpms
     size: 95708
     checksum: sha256:baf95ffbf40ee014135f16fe33e343faf7ff1ca06509fd97cd988e6afeabf670
     name: zlib
@@ -3943,841 +3943,841 @@ arches:
     sourcerpm: zlib-1.2.11-40.el9.src.rpm
   source:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/container-selinux-2.235.0-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 51091
     checksum: sha256:f50793ce3b42d12a5d1429fe9339f656a94df997e3ee27a1416a699138f40e61
     name: container-selinux
     evr: 4:2.235.0-2.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/delve-1.24.1-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 9616554
     checksum: sha256:1e062bf60083836bff9b92184c87d2c15034512f45631ffdb1121c31b2b54ddd
     name: delve
     evr: 1.24.1-2.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/e/emacs-27.2-13.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 44822802
     checksum: sha256:dc07aebe8297800966894a228009968015a0787b0dfff5e24ed4406633ebca87
     name: emacs
     evr: 1:27.2-13.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/git-2.47.1-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 7707665
     checksum: sha256:dba141092f9144df6e689e08af718722aee96351a7d767175e6dd99fac392264
     name: git
     evr: 2.47.1-2.el9_6
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/golang-1.23.6-2.el9_6.src.rpm
-    repoid: rhel-for-appstream-source-rpms
-    size: 30652040
-    checksum: sha256:5bccd821e18fd419342d7d5bf2f75f7e28667b46027a6c8c2b8eaf264d6b8142
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/golang-1.23.9-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30660935
+    checksum: sha256:39ac8d05c8b29f959986380fd301c6ff9f548d377d7ecfa28dcf36ae3fa55d6f
     name: golang
-    evr: 1.23.6-2.el9_6
+    evr: 1.23.9-1.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libmpc-1.2.1-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 846236
     checksum: sha256:47774c27b65e63251f3a1cea99efbe8caed86448a573e34a44ab28ad88cc3ece
     name: libmpc
     evr: 1.2.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 12784744
     checksum: sha256:f1bf16242337d7910e8a00b94f047a5ae9fc648040321043857318d7ff7132be
     name: perl
     evr: 4:5.32.1-481.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 37030
     checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
     name: perl-Carp
     evr: 1.50-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 131573
     checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
     name: perl-Data-Dumper
     evr: 2.174-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 22653
     checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
     name: perl-Digest
     evr: 1.19-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 60213
     checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
     name: perl-Digest-MD5
     evr: 2.58-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 1915541
     checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
     name: perl-Encode
     evr: 4:3.08-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Error-0.17029-7.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 46570
     checksum: sha256:387afa8f708f97fd2f72e8d54db80a6554340eefaec6ce36b05055fc1eabd004
     name: perl-Error
     evr: 1:0.17029-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 32709
     checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
     name: perl-Exporter
     evr: 5.74-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 43503
     checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
     name: perl-File-Path
     evr: 2.18-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 89500
     checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 55697
     checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 93389
     checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 58169
     checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 295384
     checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 43653
     checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
     name: perl-MIME-Base64
     evr: 3.16-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 151174
     checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 693539
     checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 141038
     checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
     name: perl-PathTools
     evr: 3.78-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 22192
     checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 225409
     checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 318605
     checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 91508
     checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 187594
     checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 57721
     checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
     name: perl-Socket
     evr: 4:2.031-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 225886
     checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
     name: perl-Storable
     evr: 1:3.21-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 69123
     checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 23367
     checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
     name: perl-Term-Cap
     evr: 1.17-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-TermReadKey-2.38-11.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 98184
     checksum: sha256:d4f5da01fc7692c6b65a9cd180c7cc05f29163b4b580ef06118f3246621ee228
     name: perl-TermReadKey
     evr: 2.38-11.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 18773
     checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 30727
     checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 54755
     checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
     name: perl-Time-Local
     evr: 2:1.300-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 123780
     checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
     name: perl-URI
     evr: 5.09-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 32045
     checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
     name: perl-constant
     evr: 1.33-461.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 110461
     checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
     name: perl-libnet
     evr: 3.13-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 23463
     checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
     name: perl-parent
     evr: 1:0.238-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
-    repoid: rhel-for-appstream-source-rpms
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 150048
     checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
     name: perl-podlators
     evr: 1:4.14-460.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/acl-2.3.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 535332
     checksum: sha256:cb449bc6c85e0b50fa0bb98c969ff8481fee40517d8ebec5e28b72e5360fbe1e
     name: acl
     evr: 2.3.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 482234
     checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
     name: attr
     evr: 2.5.1-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1262288
     checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
     name: audit
     evr: 3.1.5-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/basesystem-11-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 9884
     checksum: sha256:5a4ed0779fc06f08115d6e06aa95486f1e1e251f8f9ddb6c7e14e811bb2e24ef
     name: basesystem
     evr: 11-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/bash-5.1.8-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 10512850
     checksum: sha256:5d7bbbf2538361be1a11846602862c3a56809b3ea43b69b86bcf407538e9e260
     name: bash
     evr: 5.1.8-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 22426920
     checksum: sha256:7e8e6c0116f7e862225990df4faaa664fe3b86198538cd350f01b3e5bd16cf41
     name: binutils
     evr: 2.35.2-63.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 498766
     checksum: sha256:0c54d337221bca2bfeafaa7ce372aed7a2fcdb1f800be609ed8579bc1187bcd4
     name: brotli
     evr: 1.0.9-7.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 824335
     checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
     name: bzip2
     evr: 1.0.8-10.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/ca-certificates-2024.2.69_v8.0.303-91.4.el9_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 692817
     checksum: sha256:5d09821ddc46c205eb97656c88a7a553182882e56bfc55fad760a3b1c973ca05
     name: ca-certificates
     evr: 2024.2.69_v8.0.303-91.4.el9_4
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/chkconfig-1.24-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 214658
     checksum: sha256:b2618b278f5c8d6dacfae790c8c73b1fc1578b8f64011f325ced5a4a2e3b58bc
     name: chkconfig
     evr: 1.24-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/coreutils-8.32-39.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 5692590
     checksum: sha256:f042749974d210ad9049ffcb68172e4eaf91e3c0c249b33620e1f94effe82e6d
     name: coreutils
     evr: 8.32-39.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cracklib-2.9.6-27.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 6414228
     checksum: sha256:56a815a100d75c1d42c07090b632f05e51ea6d17df097d2936ab25d9aca49310
     name: cracklib
     evr: 2.9.6-27.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/crypto-policies-20250128-1.git5269e22.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 102787
     checksum: sha256:0f6081ad96e9d7cb80aa18736e3a06bbf7d2c19bdc0f95a707a4f3ed0926b878
     name: crypto-policies
     evr: 20250128-1.git5269e22.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/curl-7.76.1-31.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2551840
     checksum: sha256:f0bbcabf62bb18a18bbf9029459fa0fba4488f4b14ed114190aa77fa04c1fc9f
     name: curl
     evr: 7.76.1-31.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 4030574
     checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
     name: cyrus-sasl
     evr: 2.1.27-21.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dbus-1.12.20-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2143916
     checksum: sha256:3fe74a2b4fb4485c93e974010d9376e30a63dfcc628bfd6c01837c27b4953912
     name: dbus
     evr: 1:1.12.20-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dbus-broker-28-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 254475
     checksum: sha256:aced3097fbb8a424ca1816b8cb3e79960a9ccf7ba139538282886e692c317b29
     name: dbus-broker
     evr: 28-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1477522
     checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
     name: diffutils
     evr: 3.7-12.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 7418303
     checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
     name: e2fsprogs
     evr: 1.46.5-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.192-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 11943728
     checksum: sha256:b5a00f4c49b8980167b250ed7f9e18b90162087cac06276a4fb4ce578a1e3d5a
     name: elfutils
     evr: 0.192-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/expat-2.5.0-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 8369732
     checksum: sha256:736df300c50aad5de613ee8322bedb9522042024a95df9c886089e225bc764f7
     name: expat
     evr: 2.5.0-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/filesystem-3.16-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 20486
     checksum: sha256:c795690df30c46e521372e2f649c995a2abc159b76c8ef6cd5da8a713ea17937
     name: filesystem
     evr: 3.16-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/findutils-4.8.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2010585
     checksum: sha256:48bd4d4dd081120bcc6ab772b930a150f30b2fc89a4a14a24220383d24a30b3f
     name: findutils
     evr: 1:4.8.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gawk-5.1.0-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3190934
     checksum: sha256:37571947707e835d36ceb5641b187aba13ef8f5f605a6762ce72aeea3e745b8d
     name: gawk
     evr: 5.1.0-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 81877102
     checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
     name: gcc
     evr: 11.5.0-5.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gdbm-1.23-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1130147
     checksum: sha256:ad42264274c2a792220395a4dbe736a1de6100c4e14611707ec1dd447583271f
     name: gdbm
     evr: 1:1.23-1.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.14.src.rpm
-    repoid: rhel-for-baseos-source-rpms
-    size: 19817684
-    checksum: sha256:afd2246bd19e857541d0cd006dcad75fe7f06a72e14727ddd706cdb22a5aaaa3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.19.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19833749
+    checksum: sha256:31103580ae730950f247bd216d727857590c6349a5958ad5c053fdd42824fbaf
     name: glibc
-    evr: 2.34-168.el9_6.14
+    evr: 2.34-168.el9_6.19
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gmp-6.2.0-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2503825
     checksum: sha256:d0d8a795eea9ae555da63fbcfc3575425e86bb7e96d117b9ae2785b4f5e82f7c
     name: gmp
     evr: 1:6.2.0-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/grep-3.6-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1620891
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 4138121
     checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
     name: groff
     evr: 1.22.4-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 856147
     checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
     name: gzip
     evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/json-c-0.14-11.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 341227
     checksum: sha256:c4c76ebfd66ba6d00edf672797d7f077b29d279b7866a04e05258a257a5bc306
     name: json-c
     evr: 0.14-11.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.18.1.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
-    size: 149273518
-    checksum: sha256:064936ac5cefb82be159f25be1804f5450d09e1f895c2f831a84060309519211
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.22.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 149293080
+    checksum: sha256:04ae878f1117937f80e560346f556ceb307ca14f39d9dabe549c402480228edb
     name: kernel
-    evr: 5.14.0-570.18.1.el9_6
+    evr: 5.14.0-570.22.1.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 150790
     checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
     name: keyutils
     evr: 1.6.3-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 582431
     checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
     name: kmod
     evr: 28-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/krb5-1.21.1-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 8929002
     checksum: sha256:bbcf124c1665c99bde00f0e2e7faee6ef1efb88dd49f2a9adf8aaf019bf5124f
     name: krb5
     evr: 1.21.1-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 385311
     checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
     name: less
     evr: 590-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libarchive-3.5.3-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 7049522
     checksum: sha256:9d7c7ddde6a8bfe92e4bbdb5e63c25419cb2e997047097ac8fbc7e7c4a3fbd91
     name: libarchive
     evr: 3.5.3-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcap-2.48-9.el9_2.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 202341
     checksum: sha256:cf258d269e2690617bbace76ec328e55c6f1431ddb47b67bcd4841472870d483
     name: libcap
     evr: 2.48-9.el9_2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcap-ng-0.8.2-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 470599
     checksum: sha256:48bb098662e2f3e1dbb94e27e4e612bc6794fbb62708e1f1a431cc2480fcdb00
     name: libcap-ng
     evr: 0.8.2-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 276760
     checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
     name: libcbor
     evr: 0.7.0-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libdb-5.3.28-55.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 35290654
     checksum: sha256:28c77966dc7ce27e5c6e6a1e069d97dcc25529ab0b902f2d0816fd06879ade43
     name: libdb
     evr: 5.3.28-55.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libeconf-0.4.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 201501
     checksum: sha256:4541a0915eca1e6fd1440253cf6bdfc5482c7b6dd3d3c7310a77faf852b7671a
     name: libeconf
     evr: 0.4.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 531597
     checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
     name: libedit
     evr: 3.1-38.20210216cvs.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libevent-2.1.12-8.el9_4.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1123179
     checksum: sha256:8c00dc837b8685fc660cc0bcdfd4f533888facaa8c83655c26d2fb068cb7b135
     name: libevent
     evr: 2.1.12-8.el9_4
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libffi-3.4.2-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1367398
     checksum: sha256:2b384204cc70c8f23d3a86e5cc9f736306a7a91a72e282044e3b23f3fd831647
     name: libffi
     evr: 3.4.2-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 865138
     checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
     name: libfido2
     evr: 1.13.0-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3981814
     checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
     name: libgcrypt
     evr: 1.10.0-11.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 994101
     checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
     name: libgpg-error
     evr: 1.42-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libidn2-2.3.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2214169
     checksum: sha256:c27f21437a76f07b0ee9f4f7e61d621cbb9c483c14563b31e55e320d19df99a6
     name: libidn2
     evr: 2.3.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 9160109
     checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
     name: libpsl
     evr: 0.21.1-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpwquality-1.4.4-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 447225
     checksum: sha256:14fbf335e2c6f22b441a9750a69b7c41e197c4dd21adac701fd81f17660ee0b4
     name: libpwquality
     evr: 1.4.4-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libseccomp-2.5.2-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 653169
     checksum: sha256:43dd0fa2cd26306e2017704075e628bbe675c8731b17848df82f3b59337f1be8
     name: libseccomp
     evr: 2.5.2-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 271153
     checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
     name: libselinux
     evr: 3.6-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 223978
     checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
     name: libsemanage
     evr: 3.6-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsepol-3.6-2.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 538074
     checksum: sha256:2e02ff0ce3c6767962d1e7a3fbe657ea2a241bcd1c0182d9c552321ba4f8404b
     name: libsepol
     evr: 3.6-2.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsigsegv-2.13-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 473267
     checksum: sha256:734651070d0113de033da80114b416931c4c0be21ce51f6b1c1641b1185c34f3
     name: libsigsegv
     evr: 2.13-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-13.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 670226
     checksum: sha256:27606f3c6b33c346dec927f99a56cece41b09a0780b8c3d33599bb9020a5906f
     name: libssh
     evr: 0.10.4-13.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libtasn1-4.16.0-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1895591
     checksum: sha256:a3d9612fc631100fa0a528d7721bdee96acc33e35befb6a96544526eae169936
     name: libtasn1
     evr: 4.16.0-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libtool-2.4.6-46.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1002417
     checksum: sha256:1130b15333736ad40a18b5924959a8b0c6c151305bc252c0cbd5276432e10002
     name: libtool
     evr: 2.4.6-46.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libunistring-0.9.10-15.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2065802
     checksum: sha256:f6c329a60743d0d4955e070c5104407e47795b1ef617e7e59d052298961aec2b
     name: libunistring
     evr: 0.9.10-15.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libutempter-1.2.1-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 30093
     checksum: sha256:e48843d2734fefad084a86165860ea9575bdc53f63bb5845d8807ce9ccb4f914
     name: libutempter
     evr: 1.2.1-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 396005
     checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
     name: libverto
     evr: 0.3.2-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 543970
     checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
     name: libxcrypt
     evr: 4.4.18-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libxml2-2.9.13-9.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3279461
     checksum: sha256:2546fa0329554520374ba2095e925f5647e0c9b22bb2ea242ccbbe025183c5c5
     name: libxml2
     evr: 2.9.13-9.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lua-5.4.4-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 521629
     checksum: sha256:18feaae23ff1b674acccf0f081f0d3c36ca482df0c468e9368d4f4432dff820c
     name: lua
     evr: 5.4.4-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lz4-1.9.3-5.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 333421
     checksum: sha256:44e9e079f0f30476a0d8d9849ef1cd940fcc37abee11f481d6043b184bd0cf14
     name: lz4
     evr: 1.9.3-5.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/make-4.3-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2335546
     checksum: sha256:a5cc45d6c158b255cda528c496dbb8bc7783acb9898b97a39a1811230e102d7c
     name: make
     evr: 1:4.3-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/mpfr-4.1.0-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1556195
     checksum: sha256:1a6f60487d5ebb8998718c8246a49baf182e27318aa16e6a80b1ba7600b74e13
     name: mpfr
     evr: 4.1.0-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3587693
     checksum: sha256:0aa2d8068439cb17c73b678a8c9290e3e9aef0011b7aaa9fa5b24739297b22e4
     name: ncurses
     evr: 6.2-10.20210508.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/nghttp2-1.43.0-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3998164
     checksum: sha256:6ae71ec17624d7e1e0565a6dc4cff9cb7b88b5bf412d37744703f5a3b5a8a00b
     name: nghttp2
     evr: 1.43.0-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openldap-2.6.8-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 6548889
     checksum: sha256:0d21c12c55d40d1fc2f006c8ec187b5fcc799b794cfd31ed2d98434189c62800
     name: openldap
     evr: 2.6.8-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2415807
     checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
     name: openssh
     evr: 8.7p1-45.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.2.2-6.el9_5.1.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 17985138
     checksum: sha256:56c0b951be3e5ad6a1da594f9d4f09b8b752e2fb3d6827bcc03892f22f622b22
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-fips-provider-3.0.7-6.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 89980613
     checksum: sha256:4c7cd5a5b7095fcaa5850322ef1f1a7f42e69eacb0386d32fd6ced3dd7a9e7f5
     name: openssl-fips-provider
     evr: 3.0.7-6.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/p11-kit-0.25.3-3.el9_5.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1027881
     checksum: sha256:de598a2e1ca170df85cd69d6cc406402407a244988506f53f8736a7546135260
     name: p11-kit
     evr: 0.25.3-3.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pam-1.5.1-23.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1116237
     checksum: sha256:6f1b61c1038266830d09be523ff9a25b8a133e6253efaac6ddc0e17479fcedbc
     name: pam
     evr: 1.5.1-23.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pcre-8.44-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1624356
     checksum: sha256:7edbd87b866a3f6e3df1426d660b902e063193d6186027bf99f6d77626a43817
     name: pcre
     evr: 8.44-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pcre2-10.40-6.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1789790
     checksum: sha256:a570f7192be555222aa3704882b9199fb013a84ad4d7dcf40a93d8de2ecf6e0a
     name: pcre2
     evr: 10.40-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 310904
     checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
     name: pkgconf
     evr: 1.7.3-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/policycoreutils-3.6-2.1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 7982064
     checksum: sha256:3ee0c11e4cb602eb81993a8492688246c3d750bc0f592ba895dbce0aa734580a
     name: policycoreutils
     evr: 3.6-2.1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/popt-1.18-8.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 595630
     checksum: sha256:1c5d47907a884ec21001c4965013fa70bea3f770d385fdc897cb7afc1cf62fe6
     name: popt
     evr: 1.18-8.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 93646
     checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
     name: publicsuffix-list
     evr: 20210518-3.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/readline-8.1-4.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 3009702
     checksum: sha256:bc7a168b7275d1f9bd0f16b47029dd857ddce83fa80c3cb32eac63cb55f591f3
     name: readline
     evr: 8.1-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/redhat-release-9.6-0.1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 62469
     checksum: sha256:6720f3d5c6675bbf8d79ce5424f891a34303e0c5c39be0e52ca51f70107f585b
     name: redhat-release
     evr: 9.6-0.1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 4490587
     checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
     name: rpm
     evr: 4.16.1.3-37.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/sed-4.8-9.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1424192
     checksum: sha256:0590550f0cbdce0a26f98a73c756f663a7f220486d10f9c16d1ce0c8c4d14378
     name: sed
     evr: 4.8-9.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/selinux-policy-38.1.53-5.el9_6.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1165990
     checksum: sha256:d2d67cbefde4402aaf8d4ea0e0820683f183d388c43c3bc7841beefceca1af68
     name: selinux-policy
     evr: 38.1.53-5.el9_6
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/setup-2.13.7-10.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 195940
     checksum: sha256:3acdbbd63bd77dd8b18210b9d597bd59ddf455ff728067638c54194ac3a8a32b
     name: setup
     evr: 2.13.7-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/shadow-utils-4.9-12.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1715281
     checksum: sha256:26fa86de6d2a5c08e93fc51ec4859635e74bcaec9480641bbb69cfce12ca21ab
     name: shadow-utils
     evr: 2:4.9-12.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/sqlite-3.34.1-7.el9_3.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 25111350
     checksum: sha256:fec74797bb608a73391edf63dd9d4828664ccd8254485f91de39c4b5583d8cb6
     name: sqlite
     evr: 3.34.1-7.el9_3
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-51.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 43223467
     checksum: sha256:fd06bfa3f3ee8b7d0f563715a2362c9220bacd78b7ae099690e7439999c5eb05
     name: systemd
     evr: 252-51.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-7.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2261512
     checksum: sha256:d002c400d29e7305fe8a982ab6b9f49ee7a8780e4574b86fc0c5b3d5510ecb22
     name: tar
     evr: 2:1.34-7.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2025b-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 904607
     checksum: sha256:a2668d1f6b053545a5824a428755484895d72475a9d3833cbfbec9e08660aba2
     name: tzdata
     evr: 2025b-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/u/util-linux-2.37.4-21.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 6281028
     checksum: sha256:cde2d6a98345d49de9d225fc3acf7542fb35fde32832f1361415486a7839c222
     name: util-linux
     evr: 2.37.4-21.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1168293
     checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
     name: xz
     evr: 5.2.5-8.el9_0
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/z/zlib-1.2.11-40.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 561153
     checksum: sha256:e47b884c132983fd0cc40c761de72e1a34ada9ee395cfe50997f9fb9257669d8
     name: zlib
     evr: 1.2.11-40.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
-    repoid: rhel-for-baseos-source-rpms
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2378112
     checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
     name: zstd


### PR DESCRIPTION
This commit introduces new PipelineRun YAML files for both RHEL8 and RHEL9 versions of the openshift-selinuxd containers.