### PR TITLE
switch to tekton-catalog for rpms-signature-scan task

### DIFF
--- a/.tekton/openshift-selinuxd-rhel8-container-release-0-9-pull-request.yaml
+++ b/.tekton/openshift-selinuxd-rhel8-container-release-0-9-pull-request.yaml
@@ -607,7 +607,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan@sha256:00a29b6f86c2b8237077a5f5ca29a71aae59eab311dde57de27e5dcf4cae5d77
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/openshift-selinuxd-rhel8-container-release-0-9-push.yaml
+++ b/.tekton/openshift-selinuxd-rhel8-container-release-0-9-push.yaml
@@ -604,7 +604,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan@sha256:00a29b6f86c2b8237077a5f5ca29a71aae59eab311dde57de27e5dcf4cae5d77
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/openshift-selinuxd-rhel9-container-release-0-9-pull-request.yaml
+++ b/.tekton/openshift-selinuxd-rhel9-container-release-0-9-pull-request.yaml
@@ -606,7 +606,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan@sha256:00a29b6f86c2b8237077a5f5ca29a71aae59eab311dde57de27e5dcf4cae5d77
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/openshift-selinuxd-rhel9-container-release-0-9-push.yaml
+++ b/.tekton/openshift-selinuxd-rhel9-container-release-0-9-push.yaml
@@ -604,7 +604,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan@sha256:00a29b6f86c2b8237077a5f5ca29a71aae59eab311dde57de27e5dcf4cae5d77
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Similar to https://github.com/openshift/cac-content-fork/pull/51

We need to switch to using tekton-catalog image repo.