### PR TITLE
Use different branch prefix for mintmaker updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+    "branchPrefix": "kflux/mintmaker/"
+}


### PR DESCRIPTION
As we are using konlux branch to pull upload changes from upstream, we need to use a different branch for mintmaker.