### PR TITLE
Allow mintmaker updates at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-    "branchPrefix": "kflux/mintmaker/"
+    "branchPrefix": "kflux/mintmaker/",
+    "schedule": ["at any time"]
 }


### PR DESCRIPTION
Allow mintmaker to run outside of default schedule.

This will allows us to update the pipelines before the weekend.